### PR TITLE
fix(selector/service): Fix cli deploy auto select service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ zeabur
 
 # dist
 dist/
+
+# cli running assets
+zeabur.zip

--- a/internal/cmd/context/set/set.go
+++ b/internal/cmd/context/set/set.go
@@ -285,7 +285,7 @@ func selectService(f *cmdutil.Factory, opts *Options) error {
 
 	projectID := f.Config.GetContext().GetProject().GetID()
 
-	serviceInfo, _, err := f.Selector.SelectService(projectID)
+	serviceInfo, _, err := f.Selector.SelectService(projectID, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -80,7 +80,7 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 
 	f.Log.Info("Select one service to deploy or create a new one.")
 
-	_, service, err := f.Selector.SelectService(project.ID)
+	_, service, err := f.Selector.SelectService(project.ID, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/fill/fill.go
+++ b/pkg/fill/fill.go
@@ -109,7 +109,7 @@ func (f *paramFiller) Service(projectID, serviceID *string) (changed bool, err e
 		return false, err
 	}
 
-	_, service, err := f.selector.SelectService(*projectID)
+	_, service, err := f.selector.SelectService(*projectID, true)
 	if err != nil {
 		return false, err
 	}
@@ -146,7 +146,7 @@ func (f *paramFiller) ServiceByName(projectCtx zcontext.Context, serviceID, serv
 
 	// if service name is empty, ask user to select a service by project id
 	if *serviceName == "" {
-		service, _, err := f.selector.SelectService(projectCtx.GetProject().GetID())
+		service, _, err := f.selector.SelectService(projectCtx.GetProject().GetID(), true)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -25,7 +25,7 @@ type (
 	}
 
 	ServiceSelector interface {
-		SelectService(projectID string) (zcontext.BasicInfo, *model.Service, error)
+		SelectService(projectID string, auto bool) (zcontext.BasicInfo, *model.Service, error)
 	}
 
 	EnvironmentSelector interface {
@@ -105,7 +105,7 @@ func (s *selector) SelectProject() (zcontext.BasicInfo, *model.Project, error) {
 
 }
 
-func (s *selector) SelectService(projectID string) (zcontext.BasicInfo, *model.Service, error) {
+func (s *selector) SelectService(projectID string, auto bool) (zcontext.BasicInfo, *model.Service, error) {
 	services, err := s.client.ListAllServices(context.Background(), projectID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get services: %w", err)
@@ -115,7 +115,7 @@ func (s *selector) SelectService(projectID string) (zcontext.BasicInfo, *model.S
 		return nil, nil, nil
 	}
 
-	if len(services) == 1 {
+	if len(services) == 1 && auto {
 		s.log.Infof("Only one service in current project, select <%s> automatically\n", services[0].Name)
 		service := services[0]
 		return zcontext.NewBasicInfo(service.ID, service.Name), service, nil


### PR DESCRIPTION
This pull request fixes `zeabur deploy` auto select service bug.  **This pull request is the base of #81**
- Add zeabur.zip into gitignore
- Fixed the bug that when selecting a service with only one service, this service was automatically selected and no create new service option was offered
