### PR TITLE
fix(util/pack): Fix code upload deploy zip error

### DIFF
--- a/internal/util/pack.go
+++ b/internal/util/pack.go
@@ -1,9 +1,13 @@
 package util
 
 import (
+	"archive/zip"
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func PackZip() ([]byte, string, error) {
@@ -33,18 +37,68 @@ func PackGitRepo() ([]byte, error) {
 	output := "--output=zeabur.zip"
 
 	cmd := exec.Command("git", "archive", format, output, "HEAD")
-	out, err := cmd.CombinedOutput()
+	_, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+
+	zipBytes, err := os.ReadFile("zeabur.zip")
+	if err != nil {
+		return nil, err
+	}
+
+	return zipBytes, nil
 }
 
 func PackZipFile() ([]byte, error) {
-	cmd := exec.Command("zip", "-r", "zeabur.zip", ".")
-	out, err := cmd.CombinedOutput()
+	buf := new(bytes.Buffer)
+	srcDir := "."
+
+	zipWriter := zip.NewWriter(buf)
+
+	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.Join(".", path)
+
+		if info.IsDir() {
+			header.Name += "/"
+		} else {
+			header.Method = zip.Deflate
+		}
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			_, err = io.Copy(writer, file)
+			return err
+		}
+
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+
+	err = zipWriter.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }

--- a/internal/util/pack.go
+++ b/internal/util/pack.go
@@ -52,11 +52,14 @@ func PackGitRepo() ([]byte, error) {
 
 func PackZipFile() ([]byte, error) {
 	buf := new(bytes.Buffer)
-	srcDir := "."
+	srcDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
 
 	zipWriter := zip.NewWriter(buf)
 
-	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/internal/util/pack.go
+++ b/internal/util/pack.go
@@ -41,18 +41,17 @@ func PackGitRepo() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	zipBytes, err := os.ReadFile("zeabur.zip")
-	if err != nil {
-		return nil, err
-	}
-
 	defer func() {
 		err = os.Remove("zeabur.zip")
 		if err != nil {
 			fmt.Println(err)
 		}
 	}()
+
+	zipBytes, err := os.ReadFile("zeabur.zip")
+	if err != nil {
+		return nil, err
+	}
 
 	return zipBytes, nil
 }
@@ -65,6 +64,12 @@ func PackZipFile() ([]byte, error) {
 	}
 
 	zipWriter := zip.NewWriter(buf)
+	defer func() {
+		err = zipWriter.Close()
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
 
 	err = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -101,11 +106,6 @@ func PackZipFile() ([]byte, error) {
 		return nil
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	err = zipWriter.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/pack.go
+++ b/internal/util/pack.go
@@ -47,6 +47,13 @@ func PackGitRepo() ([]byte, error) {
 		return nil, err
 	}
 
+	defer func() {
+		err = os.Remove("zeabur.zip")
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
+
 	return zipBytes, nil
 }
 

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -354,6 +354,7 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 
 	var requestBody bytes.Buffer
 	multipartWriter := multipart.NewWriter(&requestBody)
+	defer multipartWriter.Close()
 
 	err := multipartWriter.WriteField("environment", environmentID)
 	if err != nil {
@@ -378,9 +379,11 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 		return nil, err
 	}
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 
-	req, err := http.NewRequest(method, url, &requestBody)
+	req, err := http.NewRequestWithContext(ctx, method, url, &requestBody)
 	if err != nil {
 		fmt.Println(err)
 		return nil, err
@@ -396,6 +399,10 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 		fmt.Println(err)
 		return nil, err
 	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("status code: %d, ", res.StatusCode)
+	}
+
 	defer res.Body.Close()
 
 	return nil, nil

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/spf13/viper"
@@ -405,13 +404,6 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	}
 
 	defer res.Body.Close()
-
-	defer func() {
-		err := os.Remove("zeabur.zip")
-		if err != nil {
-			panic(err)
-		}
-	}()
 
 	return nil, nil
 }

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -380,7 +380,7 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	}
 
 	client := &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, url, &requestBody)

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/spf13/viper"
@@ -404,6 +405,13 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	}
 
 	defer res.Body.Close()
+
+	defer func() {
+		err := os.Remove("zeabur.zip")
+		if err != nil {
+			panic(err)
+		}
+	}()
 
 	return nil, nil
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This pull request fixes `zeabur deploy` upload error and multiple improvements. **This pull request should be merged after #80 solved**

Issues:
- `zeabur deploy` upload multipart file's size is 0B
- `zeabur deploy` upload has no timeout restriction and lack of closing multipartWriter.
- `zeabur deploy` upload doesn't use `http.NewRequestWithContext` to utilize lifecycle of context
- `zeabur deploy` upload has no error handle after receiving request
-  PackZipFile function still depends on external command `zip` to generate file
-  PackGitRepo function lacks of removing zeabur.zip asset after uploading

Solutions:
- Implement return byte stream of archive file in PackGitRepo function
- Add http client timeout restrict in `http.Client` in UploadZipToService function
- Add defer closure in UploadZipToService function to prune multipartWriter
- Use `http.NewRequestWithContext` in UploadZipToService function
- Add http.StatusCode check after request
- Rewrite PackZipFile function using std library `archive/zip` instead of depending on `zip` command
- Implement defer closure to remove zeabur.zip after PackGitRepo function proceeded

#### Related issues & labels (optional)

- Closes 
- Suggested label: bug