### PR TITLE
chore: change the selection prompt for selecting reigon

### DIFF
--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -60,12 +60,12 @@ func runCreateInteractive(f *cmdutil.Factory, opts *Options) error {
 	regions = regions[1:]
 	s.Stop()
 
-	regionIDs := make([]string, 0, len(regions))
+	regionOptions := make([]string, 0, len(regions))
 	for _, region := range regions {
-		regionIDs = append(regionIDs, region.ID)
+		regionOptions = append(regionOptions, fmt.Sprintf("%s (%s)", region.Description, region.Name))
 	}
 
-	projectRegionIndex, err := f.Prompter.Select("Select project region", "", regionIDs)
+	projectRegionIndex, err := f.Prompter.Select("Select project region", "", regionOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -79,12 +79,12 @@ func (s *selector) SelectProject() (zcontext.BasicInfo, *model.Project, error) {
 		}
 		regions = regions[1:]
 
-		regionIDs := make([]string, 0, len(regions))
+		regionOptions := make([]string, 0, len(regions))
 		for _, region := range regions {
-			regionIDs = append(regionIDs, region.ID)
+			regionOptions = append(regionOptions, fmt.Sprintf("%s (%s)", region.Description, region.Name))
 		}
 
-		projectRegionIndex, err := s.prompter.Select("Select project region", "", regionIDs)
+		projectRegionIndex, err := s.prompter.Select("Select project region", "", regionOptions)
 		if err != nil {
 			return nil, nil, fmt.Errorf("select project region failed: %w", err)
 		}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR changes the displayed message for selecting region when creating services:

before:

![image](https://github.com/zeabur/cli/assets/20221408/503efbb4-912f-4d34-aa79-99978d82a1d1)


after:

![image](https://github.com/zeabur/cli/assets/20221408/b7934c5e-6120-4aa0-b136-c97e5ba8f7bf)


the name pattern of region takes references from what shown on AWS console:

![image](https://github.com/zeabur/cli/assets/20221408/6bf6b25d-5121-4339-ac05-3565b556fb58)


<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->
