### PR TITLE
fix: fix zeabur commandline completion

### DIFF
--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -19,7 +19,7 @@ const (
 
 func NewCmdCompletion(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "completion [bash|zsh|fish|powershell]",
+		Use:                   "zeabur completion [bash|zsh|fish|powershell]",
 		Short:                 "Generate completion script",
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{ShellBash, ShellZsh, ShellFish, ShellPowerShell},


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR fix the completion command for `zeabur`.

when generating completion, cobra would take the `Name()` method for the command, which would be the first word in the `Usage` field:

![image](https://github.com/zeabur/cli/assets/20221408/3f20152d-31cd-4110-bfd0-1dd46abbe0c9)

so in this case, the `Usage` field should be the full command of the usage, and start with `zeabur`.

otherwise, the generated completion script would confused with the command:

completion script which is not expected:
![image](https://github.com/zeabur/cli/assets/20221408/8d4eb62f-cab4-4652-9b73-ae1c050a793b)



completion script which is expected:

![image](https://github.com/zeabur/cli/assets/20221408/85572e90-9212-4d94-88ee-481ab342bede)



<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->
