### PR TITLE
refactor(api/service): Migrates to createPrebuiltService

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -277,7 +277,7 @@ func (c *client) GetPrebuiltItems(ctx context.Context) ([]model.PrebuiltItem, er
 
 func (c *client) CreatePrebuiltService(ctx context.Context, projectID string, marketplaceCode string) (*model.Service, error) {
 	var mutation struct {
-		CreatePrebuiltService model.Service `graphql:"createGenericService(projectID: $projectID, marketplaceCode: $marketplaceCode)"`
+		CreatePrebuiltService model.Service `graphql:"createPrebuiltService(projectID: $projectID, marketplaceCode: $marketplaceCode)"`
 	}
 
 	err := c.Mutate(ctx, &mutation, V{


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

`createGenericService` has been deprecated. We migrate to the new `createPrebuiltService`.
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3037<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
