### PR TITLE
feat(api/template): Passing projectID to DeployTemplate

### DIFF
--- a/internal/cmd/template/deploy/deploy.go
+++ b/internal/cmd/template/deploy/deploy.go
@@ -76,10 +76,8 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 		}
 	}
 
-	if f.Interactive {
-		if _, err := f.ParamFiller.Project(&opts.projectID); err != nil {
-			return err
-		}
+	if _, err := f.ParamFiller.ProjectCreatePreferred(&opts.projectID); err != nil {
+		return err
 	}
 
 	type RawTemplate struct {
@@ -151,7 +149,6 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 	)
 
 	s.Start()
-
 	res, err := f.ApiClient.DeployTemplate(
 		context.Background(),
 		string(file),

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -107,7 +107,13 @@ type (
 		ListAllTemplates(ctx context.Context) (model.Templates, error)
 		GetTemplate(ctx context.Context, code string) (*model.Template, error)
 
-		DeployTemplate(ctx context.Context, rawSpecYaml string, variables model.Map, repoConfigs model.RepoConfigs) (*model.Project, error)
+		DeployTemplate(
+			ctx context.Context,
+			rawSpecYaml string,
+			variables model.Map,
+			repoConfigs model.RepoConfigs,
+			projectID string,
+		) (*model.Project, error)
 		DeleteTemplate(ctx context.Context, code string) error
 	}
 )

--- a/pkg/api/template.go
+++ b/pkg/api/template.go
@@ -46,12 +46,24 @@ func (c *client) ListAllTemplates(ctx context.Context) (model.Templates, error) 
 	return templates, nil
 }
 
-func (c *client) DeployTemplate(ctx context.Context, rawSpecYaml string, variables model.Map, repoConfigs model.RepoConfigs) (*model.Project, error) {
+func (c *client) DeployTemplate(
+	ctx context.Context,
+	rawSpecYaml string,
+	variables model.Map,
+	repoConfigs model.RepoConfigs,
+	projectID string,
+) (*model.Project, error) {
 	var mutation struct {
-		DeployTemplate model.Project `graphql:"deployTemplate(rawSpecYaml: $rawSpecYaml, variables: $variables)"`
+		DeployTemplate model.Project `graphql:"deployTemplate(rawSpecYaml: $rawSpecYaml, variables: $variables, projectID: $projectID)"`
 	}
 
-	err := c.Mutate(ctx, &mutation, V{"rawSpecYaml": rawSpecYaml, "variables": variables})
+	deployParams := V{
+		"rawSpecYaml": rawSpecYaml,
+		"variables":   variables,
+		"projectID":   ObjectID(projectID),
+	}
+
+	err := c.Mutate(ctx, &mutation, deployParams)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fill/fill.go
+++ b/pkg/fill/fill.go
@@ -11,6 +11,9 @@ import (
 type ParamFiller interface {
 	// Project fills the projectID if it is empty by asking user to select a project
 	Project(projectID *string) (changed bool, err error)
+	// ProjectCreatePreferred fills the projectID if it is empty by asking user to select a project
+	// and makes "Create New Project…" the prioritized option
+	ProjectCreatePreferred(projectID *string) (changed bool, err error)
 	// ProjectByName makes sure either projectID or projectName is not empty
 	// if necessary, it will ask user to select a project first
 	ProjectByName(projectID, projectName *string) (changed bool, err error)
@@ -48,6 +51,25 @@ func (f *paramFiller) Project(projectID *string) (changed bool, err error) {
 	}
 
 	_, project, err := f.selector.SelectProject()
+	if err != nil {
+		return false, err
+	}
+
+	*projectID = project.ID
+
+	return true, nil
+}
+
+func (f *paramFiller) ProjectCreatePreferred(projectID *string) (changed bool, err error) {
+	if err = paramNilCheck(projectID); err != nil {
+		return false, err
+	}
+
+	if *projectID != "" {
+		return false, nil
+	}
+
+	_, project, err := f.selector.SelectProject(selector.WithCreatePreferred())
 	if err != nil {
 		return false, err
 	}
@@ -247,7 +269,6 @@ func (f *paramFiller) ServiceByNameWithEnvironment(opt ServiceByNameWithEnvironm
 	}
 
 	return changed1 || changed2, nil
-
 }
 
 func paramNilCheck(params ...*string) error {


### PR DESCRIPTION
#### Description (required)

For developers, `DeployTemplate` requires `ProjectID` now (you can create a project with `f.ParamFilter.Project`).

For users, you can create (or reuse) a project by the interactive UI or CLI argument, `--project-id`.

#### Related issues & labels (optional)

- Closes ZEA-3258
- Suggested label: enhancement
