### PR TITLE
chore: Upgrade CI to Go 1.22

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: "1.22"
 
       - name: install mockery
-        run: go install github.com/vektra/mockery/v2@v2.32.0
+        run: go install github.com/vektra/mockery/v2@v2.43.2
 
       - name: generate mocks
         run: make mock

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: install mockery
         run: go install github.com/vektra/mockery/v2@v2.32.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,12 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.22"
           cache: false
 
       - name: install mockery
         run: go install github.com/vektra/mockery/v2@v2.32.0
-      
+
       - name: generate mocks
         run: make mock
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           cache: false
 
       - name: install mockery
-        run: go install github.com/vektra/mockery/v2@v2.32.0
+        run: go install github.com/vektra/mockery/v2@v2.43.2
 
       - name: generate mocks
         run: make mock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           cache: true
 
       - name: install mockery
-        run: go install github.com/vektra/mockery/v2@v2.32.0
+        run: go install github.com/vektra/mockery/v2@v2.43.2
 
       - uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.22"
           cache: true
 
       - name: install mockery
         run: go install github.com/vektra/mockery/v2@v2.32.0
-      
+
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser


### PR DESCRIPTION
#### Description (required)

We have upgraded to Go toolchain to 1.21 recently. Besides, the dependency of #101 requires Go 1.22. Therefore, I bump to Go toolchain from 1.20 to 1.22.

#### Related issues & labels (optional)

- Fix #101 CI
- Suggested label:
