### PR TITLE
fix(ci): Upgrade golangci-lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,8 +29,11 @@ jobs:
       - name: generate mocks
         run: make mock
 
+      - name: download dependencies
+        run: go mod download
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.53
+          version: v1.59
           only-new-issues: true


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Upgrade golangci-lint versions.
- Download the dependencies before running `golangci-lint` (sometimes `golangci-lint` does not fetch the dependencies completely)

#### Related issues & labels (optional)

- Fix CI https://github.com/zeabur/cli/actions/runs/10194941447/job/28202582322 <!-- Add an issue number if this PR will close it. -->
- Suggested label: bug <!-- Help us triage by suggesting one of our labels that describes your PR -->
