### PR TITLE
ZEA-3791: nil pointer issue in zeabur/cli

### DIFF
--- a/pkg/fill/fill.go
+++ b/pkg/fill/fill.go
@@ -141,6 +141,11 @@ func (f *paramFiller) Service(projectID, serviceID *string) (changed bool, err e
 	if err != nil {
 		return false, err
 	}
+	if service == nil {
+		fmt.Printf("Project %s contains no services.\n\n", *projectID)
+		*projectID = ""
+		return f.Service(projectID, serviceID)
+	}
 
 	*serviceID = service.ID
 
@@ -194,6 +199,11 @@ func (f *paramFiller) ServiceByName(opt ServiceByNameOptions) (changed bool, err
 		})
 		if err != nil {
 			return false, err
+		}
+		if service == nil {
+			fmt.Printf("Project %s contains no matched services.\n\n", projectCtx.GetProject().GetID())
+			opt.ProjectCtx.ClearAll()
+			return f.ServiceByName(opt)
 		}
 
 		*serviceID = service.GetID()

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -139,6 +139,10 @@ type SelectServiceOptions struct {
 	FilterFunc func(service *model.Service) bool
 }
 
+// SelectService selects a service from the project.
+//
+// Note that it may returns nil (with no error) if there is no service in the project.
+// If user selected "Create a new service", it also returns a nil.
 func (s *selector) SelectService(opt SelectServiceOptions) (zcontext.BasicInfo, *model.Service, error) {
 	projectID := opt.ProjectID
 	auto := opt.Auto


### PR DESCRIPTION
#### Description (required)

Some functions do not handle the `service == nil` case, introducing a nil-pointer panic. This PR fixes it by letting users re-select the project.

`service == nil` is also documented now.

#### Related issues & labels (optional)

- Closes ZEA-3791
- Suggested label: bug
