### PR TITLE
Update pack.go for Windows CLI, filepath separator issue

### DIFF
--- a/internal/util/pack.go
+++ b/internal/util/pack.go
@@ -74,7 +74,7 @@ func PackZipWithoutGitIgnoreFiles() ([]byte, error) {
 		}
 
 		if info.IsDir() {
-			header.Name += "/"
+			header.Name += string(filepath.Separator)
 		} else {
 			header.Method = zip.Deflate
 		}


### PR DESCRIPTION
#### Description (required)

In Windows, pack to ZIP with wrong separator "/" instead of "\\".


#### Related issues & labels (optional)
