### PR TITLE
fix(util): Call ToSlash for Windows filename

### DIFF
--- a/internal/util/pack.go
+++ b/internal/util/pack.go
@@ -73,6 +73,9 @@ func PackZipWithoutGitIgnoreFiles() ([]byte, error) {
 			return err
 		}
 
+		// For Windows, we should replace the backslashes with forward slashes
+		header.Name = filepath.ToSlash(header.Name)
+
 		if info.IsDir() {
 			header.Name += string(filepath.Separator)
 		} else {


### PR DESCRIPTION
#### Description (required)

Turns all the `src\app\filename` to `src/app/filename`.

#### Related issues & labels (optional)

- Closes ZEA-4045
- Suggested label: `bug`
