### PR TITLE
fix(util): Do not use filepath.Separator in the zip file

### DIFF
--- a/internal/util/pack.go
+++ b/internal/util/pack.go
@@ -77,7 +77,7 @@ func PackZipWithoutGitIgnoreFiles() ([]byte, error) {
 		header.Name = filepath.ToSlash(header.Name)
 
 		if info.IsDir() {
-			header.Name += string(filepath.Separator)
+			header.Name += "/"
 		} else {
 			header.Method = zip.Deflate
 		}


### PR DESCRIPTION
#### Description (required)

Reverts #110. Internally we accept only filepath composed with `/`.

#### Related issues & labels (optional)

- Closes ZEA-4046
- Suggested label: `bug`
