### PR TITLE
ZEA-4468: Supoort new CheckDomainAvailable API in CLI

### DIFF
--- a/internal/cmd/domain/create/create.go
+++ b/internal/cmd/domain/create/create.go
@@ -103,13 +103,13 @@ func runCreateDomainInteractive(f *cmdutil.Factory, opts *Options) error {
 		spinner.WithSuffix(" Checking domain availability ..."),
 	)
 	s.Start()
-	available, _, err := f.ApiClient.CheckDomainAvailable(context.Background(), opts.domainName, opts.IsGenerated, project.Region.ID)
+	checkDomainAvailableReply, err := f.ApiClient.CheckDomainAvailable(context.Background(), opts.domainName, opts.IsGenerated, project.Region.ID)
 	if err != nil {
 		return err
 	}
 	s.Stop()
 
-	if !available {
+	if !checkDomainAvailableReply.IsAvailable {
 		f.Log.Warnf("Domain %s is not available", opts.domainName)
 		return nil
 	}

--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -86,12 +86,15 @@ func (c *client) RemoveDomain(ctx context.Context, domain string) (bool, error) 
 	return mutation.RemoveDomain, nil
 }
 
-func (c *client) CheckDomainAvailable(ctx context.Context, domain string, isGenerated bool, region string) (bool, string, error) {
+type CheckDomainAvailableReply struct {
+	IsAvailable       bool
+	Reason            string
+	AvailableSuffixes []string
+}
+
+func (c *client) CheckDomainAvailable(ctx context.Context, domain string, isGenerated bool, region string) (CheckDomainAvailableReply, error) {
 	var mutation struct {
-		CheckDomainAvailable struct {
-			IsAvailable bool
-			Reason      string
-		} `graphql:"checkDomainAvailable(domain: $domain, isGenerated: $isGenerated, region: $region)"`
+		CheckDomainAvailable CheckDomainAvailableReply `graphql:"checkDomainAvailable(domain: $domain, isGenerated: $isGenerated, region: $region)"`
 	}
 
 	err := c.Mutate(ctx, &mutation, V{
@@ -99,10 +102,9 @@ func (c *client) CheckDomainAvailable(ctx context.Context, domain string, isGene
 		"isGenerated": isGenerated,
 		"region":      region,
 	})
-
 	if err != nil {
-		return false, "", err
+		return CheckDomainAvailableReply{}, err
 	}
 
-	return mutation.CheckDomainAvailable.IsAvailable, mutation.CheckDomainAvailable.Reason, nil
+	return mutation.CheckDomainAvailable, nil
 }

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -79,7 +79,7 @@ type (
 		AddDomain(ctx context.Context, serviceID string, environmentID string, isGenerated bool, domain string, options ...string) (*string, error)
 		ListDomains(ctx context.Context, serviceID string, environmentID string) (model.Domains, error)
 		RemoveDomain(ctx context.Context, domain string) (bool, error)
-		CheckDomainAvailable(ctx context.Context, domain string, isGenerated bool, region string) (bool, string, error)
+		CheckDomainAvailable(ctx context.Context, domain string, isGenerated bool, region string) (CheckDomainAvailableReply, error)
 	}
 
 	DeploymentAPI interface {


### PR DESCRIPTION
#### Description (required)

- **feat(api)!: Add "AvailableSuffix" field**
- **refactor: Use new CheckDomainAvailable API for hinting domain**

#### Related issues & labels (optional)

- Closes ZEA-4468
- Suggested label: enhancement
