### PR TITLE
Switch to new api.zeabur.com

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	"github.com/zeabur/cli/pkg/constant"
 	"github.com/zeabur/cli/pkg/model"
 )
 
@@ -382,7 +383,7 @@ func (c *client) CreateEmptyService(ctx context.Context, projectID string, name 
 }
 
 func (c *client) UploadZipToService(ctx context.Context, projectID string, serviceID string, environmentID string, zipBytes []byte) (*model.Service, error) {
-	url := "https://gateway.zeabur.com/projects/" + projectID + "/services/" + serviceID + "/deploy"
+	url := constant.ZeaburServerURL + "/projects/" + projectID + "/services/" + serviceID + "/deploy"
 
 	method := "POST"
 

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -1,6 +1,6 @@
 package constant
 
 const (
-	ZeaburServerURL = "https://gateway.zeabur.com"
-	WebsocketURL    = "wss://gateway.zeabur.com"
+	ZeaburServerURL = "https://api.zeabur.com"
+	WebsocketURL    = "wss://api.zeabur.com"
 )


### PR DESCRIPTION
#### Description (required)

Use `api.zeabur.com`. `gateway.zeabur.com` is migrating and some stuff (for example, API token) are not working.

- **fix(api): Use ZeaburServerURL constant**
- **feat(constant): Switch to new API endpoint**

#### Related issues & labels (optional)

- Quick workaround of SUP-1430
- Suggested label: bug
