### PR TITLE
fix: enhance error logging for template deploy

### DIFF
--- a/internal/cmd/template/deploy/deploy.go
+++ b/internal/cmd/template/deploy/deploy.go
@@ -182,7 +182,11 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 	if err != nil {
 		var graphqlErrors graphql.Errors
 		if errors.As(err, &graphqlErrors) && len(graphqlErrors) > 0 {
-			f.Log.Errorf("%s (code: %s)", graphqlErrors[0].Message, graphqlErrors[0].Extensions["code"])
+			description := ""
+			if desc, ok := graphqlErrors[0].Extensions["description"]; ok {
+				description = fmt.Sprintf("\nDescription: %s", desc)
+			}
+			f.Log.Errorf("%s (code: %s)%s", graphqlErrors[0].Message, graphqlErrors[0].Extensions["code"], description)
 			return nil
 		}
 		return err


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
This PR enhances error logging for template deployment by adding the "description" field from GraphQL errors when available. Previously, users would only see a generic error message without specific details about what was wrong with their template (this was super confusing - I personally thought there was something wrong with my account, not my template!) Now, the error output includes the detailed description that helps developers quickly identify and fix issues in their templates.

**For example**
Before:
```
$ bunx zeabur@latest template deploy -f zeabur-template.yaml
ERROR   Invalid input (code: INVALID_ARGUMENT)
```

Now:
```
$ bunx zeabur@latest template deploy -f zeabur-template.yaml
ERROR   Invalid input (code: INVALID_ARGUMENT)
Description: Invalid service spec: healthCheck, cause: schema.regex_unmatched: input "3000" does not match regex /^[a-z][a-z0-9-]{0,61}[a-z0-9]$/
```

#### Related issues & labels (optional)

- Suggested label: enhancement
