### PR TITLE
fix: correct region index mapping in template deploy when unavailable regions are filtered

### DIFF
--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -102,9 +102,11 @@ func (s *selector) SelectProject(opts ...SelectProjectOptionsApplyer) (zcontext.
 			return nil, nil, fmt.Errorf("get regions failed: %w", err)
 		}
 
+		availableRegions := make([]model.GenericRegion, 0, len(regions))
 		regionOptions := make([]string, 0, len(regions))
 		for _, region := range regions {
 			if region.IsAvailable() {
+				availableRegions = append(availableRegions, region)
 				regionOptions = append(regionOptions, region.String())
 			}
 		}
@@ -114,7 +116,7 @@ func (s *selector) SelectProject(opts ...SelectProjectOptionsApplyer) (zcontext.
 			return nil, nil, fmt.Errorf("select project region failed: %w", err)
 		}
 
-		projectRegion := regions[projectRegionIndex].GetID()
+		projectRegion := availableRegions[projectRegionIndex].GetID()
 
 		project, err := s.client.CreateProject(context.Background(), projectRegion, nil)
 		if err != nil {


### PR DESCRIPTION
Before:
<img width="1482" height="391" alt="截圖 2026-01-20 下午4 20 39" src="https://github.com/user-attachments/assets/de3f5881-be89-42c9-95b1-64930b7e9ec9" />

After:
<img width="1544" height="361" alt="截圖 2026-01-20 下午4 19 32" src="https://github.com/user-attachments/assets/f453c290-7938-4de5-804b-04833dbb5e11" />




When free tier users deploy using CLI template deploy command and select a region,
they were encountering "REQUIRE_PAID_PLAN" errors even when selecting available regions.

This was caused by an index mismatch bug in pkg/selector/selector.go where:
- regionOptions array contained only available regions (filtered)
- User selected an index from this filtered list
- Code used that index on the original unfiltered regions array

This resulted in selecting the wrong region (potentially an unavailable one).

The fix creates a separate availableRegions array and uses it for indexing,
matching the pattern already applied to internal/cmd/project/create/create.go
in commit 8e5d1ab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed region selection during project creation to ensure only available regions are properly considered, preventing errors from selecting unavailable options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->