### PR TITLE
fix: auto-resolve IDs and strip ObjectID prefixes

### DIFF
--- a/internal/cmd/deployment/get/get.go
+++ b/internal/cmd/deployment/get/get.go
@@ -69,6 +69,15 @@ func runGetInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runGetNonInteractive(f *cmdutil.Factory, opts *Options) (err error) {
+	if opts.deploymentID == "" && opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, resolveErr := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		opts.environmentID = envID
+	}
+
 	if err = paramCheck(opts); err != nil {
 		return err
 	}

--- a/internal/cmd/deployment/list/list.go
+++ b/internal/cmd/deployment/list/list.go
@@ -65,6 +65,15 @@ func runListInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runListNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	if err := paramCheck(opts); err != nil {
 		return err
 	}

--- a/internal/cmd/project/export/export.go
+++ b/internal/cmd/project/export/export.go
@@ -49,16 +49,11 @@ func runExport(f *cmdutil.Factory, opts Options) error {
 	}
 
 	if opts.EnvironmentID == "" {
-		environments, err := f.ApiClient.ListEnvironments(context.Background(), opts.ProjectID)
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, opts.ProjectID)
 		if err != nil {
-			return fmt.Errorf("list environments for project<%s> failed: %w", opts.ProjectID, err)
+			return err
 		}
-
-		if len(environments) == 0 {
-			return fmt.Errorf("no environment found in project %s", opts.ProjectID)
-		}
-
-		opts.EnvironmentID = environments[0].ID
+		opts.EnvironmentID = envID
 	}
 
 	exportedTemplate, err := f.ApiClient.ExportProject(context.Background(), opts.ProjectID, opts.EnvironmentID)

--- a/internal/cmd/service/delete/delete.go
+++ b/internal/cmd/service/delete/delete.go
@@ -67,6 +67,15 @@ func runDeleteInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runDeleteNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	if err := checkParams(opts); err != nil {
 		return err
 	}

--- a/internal/cmd/service/expose/expose.go
+++ b/internal/cmd/service/expose/expose.go
@@ -56,6 +56,15 @@ func runExpose(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runExposeNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	err := paramCheck(opts)
 	if err != nil {
 		return err

--- a/internal/cmd/service/metric/metric.go
+++ b/internal/cmd/service/metric/metric.go
@@ -79,6 +79,15 @@ func runMetricInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runMetricNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	if err := paramCheck(opts); err != nil {
 		return err
 	}

--- a/internal/cmd/service/redeploy/redeploy.go
+++ b/internal/cmd/service/redeploy/redeploy.go
@@ -68,6 +68,15 @@ func runRedeployInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runRedeployNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	if err := checkParams(opts); err != nil {
 		return err
 	}

--- a/internal/cmd/service/restart/restart.go
+++ b/internal/cmd/service/restart/restart.go
@@ -68,6 +68,15 @@ func runRestartInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runRestartNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	if err := checkParams(opts); err != nil {
 		return err
 	}

--- a/internal/cmd/service/suspend/suspend.go
+++ b/internal/cmd/service/suspend/suspend.go
@@ -68,6 +68,15 @@ func runSuspendInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runSuspendNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	if err := checkParams(opts); err != nil {
 		return err
 	}

--- a/internal/cmd/service/update/tag/tag.go
+++ b/internal/cmd/service/update/tag/tag.go
@@ -83,6 +83,15 @@ func runInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.environmentID == "" {
+		projectID := f.Config.GetContext().GetProject().GetID()
+		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
 	if err := checkParams(opts); err != nil {
 		return err
 	}

--- a/internal/util/env.go
+++ b/internal/util/env.go
@@ -1,6 +1,12 @@
 package util
 
-import "github.com/spf13/cobra"
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/pkg/api"
+)
 
 // AddEnvParam todo: support name
 func AddEnvParam(cmd *cobra.Command, id *string) {
@@ -9,4 +15,24 @@ func AddEnvParam(cmd *cobra.Command, id *string) {
 
 func AddEnvOfServiceParam(cmd *cobra.Command, id *string) {
 	cmd.Flags().StringVar(id, "env-id", "", "Environment ID of service")
+}
+
+// ResolveEnvironmentID resolves the environment ID from the project ID
+// by listing environments and returning the first one.
+// Every project has exactly one environment since environments are deprecated.
+func ResolveEnvironmentID(client api.Client, projectID string) (string, error) {
+	if projectID == "" {
+		return "", fmt.Errorf("project ID is required to resolve environment ID; please set project context with `zeabur context set project`")
+	}
+
+	environments, err := client.ListEnvironments(context.Background(), projectID)
+	if err != nil {
+		return "", fmt.Errorf("failed to list environments for project %s: %w", projectID, err)
+	}
+
+	if len(environments) == 0 {
+		return "", fmt.Errorf("no environment found for project %s", projectID)
+	}
+
+	return environments[0].ID, nil
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -41,6 +41,7 @@ func NewGraphQLClientWithToken(token string) *graphql.Client {
 
 func NewSubscriptionClient(token string) *graphql.SubscriptionClient {
 	return graphql.NewSubscriptionClient(WSSZeaburGraphQLAPIEndpoint).
+		WithProtocol(graphql.GraphQLWS).
 		WithConnectionParams(map[string]any{
 			"authToken": token,
 		})

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"strings"
+
 	"github.com/zeabur/cli/pkg/model"
 )
 
@@ -13,12 +15,24 @@ func (id MapString) GetGraphQLType() string {
 	return `Map`
 }
 
-// ObjectID is the alias ofskip, limit = normalizePagination(skip, limit) string, it's used to represent the ObjectID defined in GraphQL schema.
-type ObjectID string
+// objectID represents the ObjectID defined in GraphQL schema.
+type objectID string
 
-// GetGraphQLType returns the GraphQL type name of ObjectID.
-func (id ObjectID) GetGraphQLType() string {
+// GetGraphQLType returns the GraphQL type name of objectID.
+func (id objectID) GetGraphQLType() string {
 	return `ObjectID`
+}
+
+// ObjectID creates an objectID from a string, automatically stripping
+// any known prefix (e.g. "service-", "project-", "environment-", "deployment-").
+func ObjectID(id string) objectID {
+	if idx := strings.LastIndex(id, "-"); idx != -1 {
+		hex := id[idx+1:]
+		if len(hex) == 24 {
+			return objectID(hex)
+		}
+	}
+	return objectID(id)
 }
 
 type ServiceTemplate string

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -91,14 +91,11 @@ type (
 	}
 
 	LogAPI interface {
-		// GetRuntimeLogs returns the logs of a service, two cases of parameters:
-		// 1. only deploymentID
-		// 2. deploymentID and serviceID
-		GetRuntimeLogs(ctx context.Context, deploymentID, serviceID, environmentID string) (model.Logs, error)
+		GetRuntimeLogs(ctx context.Context, serviceID, environmentID, deploymentID string) (model.Logs, error)
 		GetBuildLogs(ctx context.Context, deploymentID string) (model.Logs, error)
 
-		WatchRuntimeLogs(ctx context.Context, deploymentID string) (<-chan model.Log, error)
-		WatchBuildLogs(ctx context.Context, deploymentID string) (<-chan model.Log, error)
+		WatchRuntimeLogs(ctx context.Context, projectID, serviceID, environmentID, deploymentID string) (<-chan model.Log, error)
+		WatchBuildLogs(ctx context.Context, projectID, deploymentID string) (<-chan model.Log, error)
 	}
 
 	GitAPI interface {


### PR DESCRIPTION
## Summary
- `ObjectID()` auto-strips prefixes like `service-`, `project-`, `environment-`, `deployment-` so users can pass prefixed IDs directly
- `deployment log --service-id` now resolves `projectID` and `environmentID` from the service itself, instead of relying on context (which may point to a different project)
- Auto-resolve `environmentID` across all commands (deployment get/list, service delete/expose/metric/redeploy/restart/suspend, update tag) since environments are deprecated
- Refactored log API to match backend GraphQL schema (subscription takes `projectID`, `serviceID`, `environmentID`)
- Use `graphql-ws` protocol for WebSocket subscriptions

## Test plan
- [x] `deployment log --service-id service-xxx` returns logs from the correct project
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)