### PR TITLE
feat: add --project-id to service list & search templates by service name

### DIFF
--- a/internal/cmd/service/list/list.go
+++ b/internal/cmd/service/list/list.go
@@ -27,7 +27,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		PreRunE: util.RunEChain(
-			util.NeedProjectContextWhenNonInteractive(f),
+			util.NeedProjectContextWhenNonInteractive(f, &opts.projectID),
 			util.DefaultIDByContext(ctx.GetEnvironment(), &opts.environmentID),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -35,6 +35,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&opts.projectID, "project-id", opts.projectID, "Project ID")
 	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
 
 	return cmd
@@ -49,10 +50,12 @@ func runList(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runListInteractive(f *cmdutil.Factory, opts *Options) error {
-	// fetch project id from context
-	opts.projectID = f.Config.GetContext().GetProject().GetID()
+	// if project id is not set by flag, fetch from context
+	if opts.projectID == "" {
+		opts.projectID = f.Config.GetContext().GetProject().GetID()
+	}
 
-	// if project id is not set, prompt to select one
+	// if project id is still not set, prompt to select one
 	if _, err := f.ParamFiller.Project(&opts.projectID); err != nil {
 		return err
 	}

--- a/internal/util/runE.go
+++ b/internal/util/runE.go
@@ -8,9 +8,13 @@ import (
 	"github.com/zeabur/cli/pkg/zcontext"
 )
 
-// NeedProjectContextWhenNonInteractive checks if the project context is set in the non-interactive mode
-func NeedProjectContextWhenNonInteractive(f *cmdutil.Factory) CobraRunE {
+// NeedProjectContextWhenNonInteractive checks if the project context is set in the non-interactive mode.
+// If overrideID is provided and non-empty, the check is skipped (the caller already has a project ID from a flag).
+func NeedProjectContextWhenNonInteractive(f *cmdutil.Factory, overrideID ...*string) CobraRunE {
 	return func(cmd *cobra.Command, args []string) error {
+		if len(overrideID) > 0 && overrideID[0] != nil && *overrideID[0] != "" {
+			return nil
+		}
 		if !f.Interactive && f.Config.GetContext().GetProject().Empty() {
 			return errors.New("please run <zeabur context set project> first")
 		}

--- a/pkg/model/template.go
+++ b/pkg/model/template.go
@@ -6,15 +6,21 @@ import (
 	"github.com/zeabur/cli/pkg/util"
 )
 
+// TemplateServiceRef is a minimal reference to a service in a template, used for GraphQL queries.
+type TemplateServiceRef struct {
+	Name string `graphql:"name"`
+}
+
 type Template struct {
-	CreatedAt     time.Time `graphql:"createdAt"`
-	DeploymentCnt int       `graphql:"deploymentCnt"`
-	Code          string    `graphql:"code"`
-	Description   string    `graphql:"description"`
-	Name          string    `graphql:"name"`
-	PreviewURL    string    `graphql:"previewURL"`
-	Readme        string    `graphql:"readme"`
-	Tags          []string  `graphql:"tags"`
+	CreatedAt     time.Time            `graphql:"createdAt"`
+	DeploymentCnt int                  `graphql:"deploymentCnt"`
+	Code          string               `graphql:"code"`
+	Description   string               `graphql:"description"`
+	Name          string               `graphql:"name"`
+	PreviewURL    string               `graphql:"previewURL"`
+	Readme        string               `graphql:"readme"`
+	Tags          []string             `graphql:"tags"`
+	Services      []TemplateServiceRef `graphql:"services"`
 }
 
 type TemplateConnection struct {


### PR DESCRIPTION
## Summary
- Add `--project-id` flag to `service list` so it can be used directly without setting context first (e.g. `zeabur service list --project-id <id>`)
- Enhance `template search` to also match service names within templates — e.g. searching "mysql" will return templates that include a MySQL service, ranked below direct title/description matches

## Test plan
- [ ] `zeabur service list --project-id <id>` works without setting context
- [ ] `zeabur template search mysql` returns templates containing MySQL services
- [ ] Title/description matches still rank above service name matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--project-id` flag to explicitly specify a project ID for non-interactive workflows
  * Implemented relevance scoring for template search results, prioritizing matches by name, description, and service relevance

* **Improvements**
  * Enhanced template search output with explicit messaging when no matching templates are found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->