### PR TITLE
feat: add service exec and resolve IDs from service

### DIFF
--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -33,7 +33,6 @@ func NewCmdDeploy(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "deploy",
 		Short:   "Deploy local project to Zeabur with one command",
-		PreRunE: util.NeedProjectContextWhenNonInteractive(f),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDeploy(f, opts)
 		},

--- a/internal/cmd/deployment/list/list.go
+++ b/internal/cmd/deployment/list/list.go
@@ -12,7 +12,6 @@ import (
 )
 
 type Options struct {
-	// todo: support service name
 	serviceID     string
 	serviceName   string
 	environmentID string
@@ -25,17 +24,14 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		Use:     "list",
 		Short:   "List deployments",
 		Aliases: []string{"ls"},
-		PreRunE: util.NeedProjectContextWhenNonInteractive(f),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(f, opts)
 		},
 	}
 
-	zctx := f.Config.GetContext()
-
-	cmd.Flags().StringVar(&opts.serviceID, "service-id", zctx.GetService().GetID(), "Service ID")
-	cmd.Flags().StringVar(&opts.serviceName, "service-name", zctx.GetService().GetName(), "Service Name")
-	cmd.Flags().StringVar(&opts.environmentID, "env-id", zctx.GetEnvironment().GetID(), "Environment ID")
+	cmd.Flags().StringVar(&opts.serviceID, "service-id", "", "Service ID")
+	cmd.Flags().StringVar(&opts.serviceName, "service-name", "", "Service Name")
+	cmd.Flags().StringVar(&opts.environmentID, "env-id", "", "Environment ID")
 
 	return cmd
 }
@@ -65,26 +61,26 @@ func runListInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runListNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	// Resolve service ID from name
+	if opts.serviceID == "" && opts.serviceName != "" {
+		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.serviceName)
+		if err != nil {
+			return fmt.Errorf("failed to get service: %w", err)
+		}
+		opts.serviceID = service.ID
+	}
+
+	if opts.serviceID == "" {
+		return errors.New("--service-id or --service-name is required")
+	}
+
+	// Resolve environment from service's project
 	if opts.environmentID == "" {
-		projectID := f.Config.GetContext().GetProject().GetID()
-		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.serviceID)
 		if err != nil {
 			return err
 		}
 		opts.environmentID = envID
-	}
-
-	if err := paramCheck(opts); err != nil {
-		return err
-	}
-
-	// If service id is not provided, get service id by service name
-	if opts.serviceID == "" {
-		if service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.serviceName); err != nil {
-			return fmt.Errorf("failed to get service: %w", err)
-		} else {
-			opts.serviceID = service.ID
-		}
 	}
 
 	deployments, err := f.ApiClient.ListAllDeployments(context.Background(), opts.serviceID, opts.environmentID)
@@ -98,18 +94,6 @@ func runListNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	f.Printer.Table(deployments.Header(), deployments.Rows())
-
-	return nil
-}
-
-func paramCheck(opts *Options) error {
-	if opts.serviceID == "" && opts.serviceName == "" {
-		return errors.New("service-id or service-name is required")
-	}
-
-	if opts.environmentID == "" {
-		return errors.New("environment is required")
-	}
 
 	return nil
 }

--- a/internal/cmd/domain/delete/delete.go
+++ b/internal/cmd/domain/delete/delete.go
@@ -22,18 +22,12 @@ type Options struct {
 
 func NewCmdDeleteDomain(f *cmdutil.Factory) *cobra.Command {
 	opts := &Options{}
-	zctx := f.Config.GetContext()
 
 	cmd := &cobra.Command{
 		Use:     "delete",
 		Short:   "Delete domain",
 		Long:    `Delete domain of a service`,
 		Aliases: []string{"del"},
-		PreRunE: util.RunEChain(
-			util.NeedProjectContextWhenNonInteractive(f),
-			util.DefaultIDNameByContext(zctx.GetService(), &opts.id, &opts.name),
-			util.DefaultIDByContext(zctx.GetEnvironment(), &opts.environmentID),
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDeleteDomain(f, opts)
 		},
@@ -112,16 +106,20 @@ func runDeleteDomainInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runDeleteDomainNonInteractive(f *cmdutil.Factory, opts *Options) error {
-	zctx := f.Config.GetContext()
+	if opts.id == "" && opts.name != "" {
+		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
+		if err != nil {
+			return err
+		}
+		opts.id = service.ID
+	}
 
-	if _, err := f.ParamFiller.ServiceByNameWithEnvironment(fill.ServiceByNameWithEnvironmentOptions{
-		ProjectCtx:    zctx,
-		ServiceID:     &opts.id,
-		ServiceName:   &opts.name,
-		EnvironmentID: &opts.environmentID,
-		CreateNew:     false,
-	}); err != nil {
-		return err
+	if opts.environmentID == "" && opts.id != "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
 	}
 
 	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,

--- a/internal/cmd/service/exec/exec.go
+++ b/internal/cmd/service/exec/exec.go
@@ -1,0 +1,110 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+	"github.com/zeabur/cli/internal/util"
+	"github.com/zeabur/cli/pkg/fill"
+)
+
+type Options struct {
+	id   string
+	name string
+
+	environmentID string
+
+	command []string
+}
+
+func NewCmdExec(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "exec -- <command> [args...]",
+		Short: "Execute a command in a service container",
+		Long:  "Execute a command in a running service's container. The command and its arguments should be specified after \"--\".",
+		Example: `  # List files in the service container
+  zeabur service exec -- ls -la
+
+  # Run a shell command
+  zeabur service exec -- sh -c "echo hello"
+
+  # Specify service by name
+  zeabur service exec --name my-svc --env-id xxx -- cat /etc/hostname`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.command = cmd.Flags().Args()
+			if len(opts.command) == 0 {
+				return fmt.Errorf("command is required, use -- to separate it from flags")
+			}
+			return runExec(f, opts)
+		},
+	}
+
+	util.AddServiceParam(cmd, &opts.id, &opts.name)
+	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
+
+	return cmd
+}
+
+func runExec(f *cmdutil.Factory, opts *Options) error {
+	if f.Interactive {
+		return runExecInteractive(f, opts)
+	}
+	return runExecNonInteractive(f, opts)
+}
+
+func runExecInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.id == "" && opts.name == "" {
+		zctx := f.Config.GetContext()
+		if _, err := f.ParamFiller.ServiceByNameWithEnvironment(fill.ServiceByNameWithEnvironmentOptions{
+			ProjectCtx:    zctx,
+			ServiceID:     &opts.id,
+			ServiceName:   &opts.name,
+			EnvironmentID: &opts.environmentID,
+			CreateNew:     false,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return runExecNonInteractive(f, opts)
+}
+
+func runExecNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.id == "" && opts.name != "" {
+		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
+		if err != nil {
+			return err
+		}
+		opts.id = service.ID
+	}
+
+	if opts.id == "" {
+		return fmt.Errorf("--id or --name is required")
+	}
+
+	if opts.environmentID == "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
+	}
+
+	result, err := f.ApiClient.ExecuteCommand(context.Background(), opts.id, opts.environmentID, opts.command)
+	if err != nil {
+		return fmt.Errorf("execute command failed: %w", err)
+	}
+
+	fmt.Print(result.Output)
+
+	if result.ExitCode != 0 {
+		os.Exit(result.ExitCode)
+	}
+
+	return nil
+}

--- a/internal/cmd/service/redeploy/redeploy.go
+++ b/internal/cmd/service/redeploy/redeploy.go
@@ -21,16 +21,10 @@ type Options struct {
 
 func NewCmdRedeploy(f *cmdutil.Factory) *cobra.Command {
 	opts := &Options{}
-	zctx := f.Config.GetContext()
 
 	cmd := &cobra.Command{
 		Use:   "redeploy",
 		Short: "redeploy a service",
-		PreRunE: util.RunEChain(
-			util.NeedProjectContextWhenNonInteractive(f),
-			util.DefaultIDNameByContext(zctx.GetService(), &opts.id, &opts.name),
-			util.DefaultIDByContext(zctx.GetEnvironment(), &opts.environmentID),
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRedeploy(f, opts)
 		},
@@ -68,26 +62,24 @@ func runRedeployInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runRedeployNonInteractive(f *cmdutil.Factory, opts *Options) error {
-	if opts.environmentID == "" {
-		projectID := f.Config.GetContext().GetProject().GetID()
-		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
-		if err != nil {
-			return err
-		}
-		opts.environmentID = envID
-	}
-
-	if err := checkParams(opts); err != nil {
-		return err
-	}
-
-	// if name is set, get service id by name
 	if opts.id == "" && opts.name != "" {
 		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
 		if err != nil {
 			return err
 		}
 		opts.id = service.ID
+	}
+
+	if opts.id == "" {
+		return fmt.Errorf("--id or --name is required")
+	}
+
+	if opts.environmentID == "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
 	}
 
 	// to show friendly message
@@ -113,18 +105,6 @@ func runRedeployNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	f.Log.Infof("Service <%s> redeployed successfully", idOrName)
-
-	return nil
-}
-
-func checkParams(opts *Options) error {
-	if opts.id == "" && opts.name == "" {
-		return fmt.Errorf("--id or --name is required")
-	}
-
-	if opts.environmentID == "" {
-		return fmt.Errorf("--env-id is required")
-	}
 
 	return nil
 }

--- a/internal/cmd/service/restart/restart.go
+++ b/internal/cmd/service/restart/restart.go
@@ -21,16 +21,10 @@ type Options struct {
 
 func NewCmdRestart(f *cmdutil.Factory) *cobra.Command {
 	opts := &Options{}
-	zctx := f.Config.GetContext()
 
 	cmd := &cobra.Command{
 		Use:   "restart",
 		Short: "restart a service",
-		PreRunE: util.RunEChain(
-			util.NeedProjectContextWhenNonInteractive(f),
-			util.DefaultIDNameByContext(zctx.GetService(), &opts.id, &opts.name),
-			util.DefaultIDByContext(zctx.GetEnvironment(), &opts.environmentID),
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRestart(f, opts)
 		},
@@ -68,26 +62,24 @@ func runRestartInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runRestartNonInteractive(f *cmdutil.Factory, opts *Options) error {
-	if opts.environmentID == "" {
-		projectID := f.Config.GetContext().GetProject().GetID()
-		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
-		if err != nil {
-			return err
-		}
-		opts.environmentID = envID
-	}
-
-	if err := checkParams(opts); err != nil {
-		return err
-	}
-
-	// if name is set, get service id by name
 	if opts.id == "" && opts.name != "" {
 		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
 		if err != nil {
 			return err
 		}
 		opts.id = service.ID
+	}
+
+	if opts.id == "" {
+		return fmt.Errorf("--id or --name is required")
+	}
+
+	if opts.environmentID == "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
 	}
 
 	// to show friendly message
@@ -113,18 +105,6 @@ func runRestartNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	f.Log.Infof("Service <%s> restarted successfully", idOrName)
-
-	return nil
-}
-
-func checkParams(opts *Options) error {
-	if opts.id == "" && opts.name == "" {
-		return fmt.Errorf("--id or --name is required")
-	}
-
-	if opts.environmentID == "" {
-		return fmt.Errorf("--env-id is required")
-	}
 
 	return nil
 }

--- a/internal/cmd/service/service.go
+++ b/internal/cmd/service/service.go
@@ -6,6 +6,7 @@ import (
 
 	serviceDeleteCmd "github.com/zeabur/cli/internal/cmd/service/delete"
 	serviceDeployCmd "github.com/zeabur/cli/internal/cmd/service/deploy"
+	serviceExecCmd "github.com/zeabur/cli/internal/cmd/service/exec"
 	serviceExposeCmd "github.com/zeabur/cli/internal/cmd/service/expose"
 	serviceGetCmd "github.com/zeabur/cli/internal/cmd/service/get"
 	serviceInstructionCmd "github.com/zeabur/cli/internal/cmd/service/instruction"
@@ -36,6 +37,7 @@ func NewCmdService(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(serviceSuspendCmd.NewCmdSuspend(f))
 	cmd.AddCommand(serviceDeleteCmd.NewCmdDelete(f))
 	cmd.AddCommand(serviceDeployCmd.NewCmdDeploy(f))
+	cmd.AddCommand(serviceExecCmd.NewCmdExec(f))
 	cmd.AddCommand(serviceInstructionCmd.NewCmdInstruction(f))
 	cmd.AddCommand(serviceNetworkCmd.NewCmdPrivateNetwork(f))
 	cmd.AddCommand(serviceUpdateCmd.NewCmdUpdate(f))

--- a/internal/cmd/service/suspend/suspend.go
+++ b/internal/cmd/service/suspend/suspend.go
@@ -21,16 +21,10 @@ type Options struct {
 
 func NewCmdSuspend(f *cmdutil.Factory) *cobra.Command {
 	opts := &Options{}
-	zctx := f.Config.GetContext()
 
 	cmd := &cobra.Command{
 		Use:   "suspend",
 		Short: "suspend a service",
-		PreRunE: util.RunEChain(
-			util.NeedProjectContextWhenNonInteractive(f),
-			util.DefaultIDNameByContext(zctx.GetService(), &opts.id, &opts.name),
-			util.DefaultIDByContext(zctx.GetEnvironment(), &opts.environmentID),
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSuspend(f, opts)
 		},
@@ -68,26 +62,24 @@ func runSuspendInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runSuspendNonInteractive(f *cmdutil.Factory, opts *Options) error {
-	if opts.environmentID == "" {
-		projectID := f.Config.GetContext().GetProject().GetID()
-		envID, err := util.ResolveEnvironmentID(f.ApiClient, projectID)
-		if err != nil {
-			return err
-		}
-		opts.environmentID = envID
-	}
-
-	if err := checkParams(opts); err != nil {
-		return err
-	}
-
-	// if name is set, get service id by name
 	if opts.id == "" && opts.name != "" {
 		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
 		if err != nil {
 			return err
 		}
 		opts.id = service.ID
+	}
+
+	if opts.id == "" {
+		return fmt.Errorf("--id or --name is required")
+	}
+
+	if opts.environmentID == "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
 	}
 
 	// to show friendly message
@@ -113,18 +105,6 @@ func runSuspendNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	f.Log.Infof("Service <%s> suspended successfully", idOrName)
-
-	return nil
-}
-
-func checkParams(opts *Options) error {
-	if opts.id == "" && opts.name == "" {
-		return fmt.Errorf("--id or --name is required")
-	}
-
-	if opts.environmentID == "" {
-		return fmt.Errorf("--env-id is required")
-	}
 
 	return nil
 }

--- a/internal/cmd/upload/upload.go
+++ b/internal/cmd/upload/upload.go
@@ -27,7 +27,6 @@ func NewCmdUpload(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upload",
 		Short:   "Upload local project to Zeabur",
-		PreRunE: util.NeedProjectContextWhenNonInteractive(f),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpload(f, opts)
 		},

--- a/internal/cmd/variable/create/create.go
+++ b/internal/cmd/variable/create/create.go
@@ -23,17 +23,11 @@ type Options struct {
 
 func NewCmdCreateVariable(f *cmdutil.Factory) *cobra.Command {
 	opts := &Options{}
-	zctx := f.Config.GetContext()
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "create variable(s)",
 		Long:  `Create variable(s) for a service`,
-		PreRunE: util.RunEChain(
-			util.NeedProjectContextWhenNonInteractive(f),
-			util.DefaultIDNameByContext(zctx.GetService(), &opts.id, &opts.name),
-			util.DefaultIDByContext(zctx.GetEnvironment(), &opts.environmentID),
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreateVariable(f, opts)
 		},
@@ -92,16 +86,24 @@ func runCreateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runCreateVariableNonInteractive(f *cmdutil.Factory, opts *Options) error {
-	zctx := f.Config.GetContext()
+	if opts.id == "" && opts.name != "" {
+		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
+		if err != nil {
+			return err
+		}
+		opts.id = service.ID
+	}
 
-	if _, err := f.ParamFiller.ServiceByNameWithEnvironment(fill.ServiceByNameWithEnvironmentOptions{
-		ProjectCtx:    zctx,
-		ServiceID:     &opts.id,
-		ServiceName:   &opts.name,
-		EnvironmentID: &opts.environmentID,
-		CreateNew:     false,
-	}); err != nil {
-		return err
+	if opts.id == "" {
+		return fmt.Errorf("--id or --name is required")
+	}
+
+	if opts.environmentID == "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
 	}
 
 	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,

--- a/internal/cmd/variable/update/update.go
+++ b/internal/cmd/variable/update/update.go
@@ -22,17 +22,11 @@ type Options struct {
 
 func NewCmdUpdateVariable(f *cmdutil.Factory) *cobra.Command {
 	opts := &Options{}
-	zctx := f.Config.GetContext()
 
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "update variable(s)",
 		Long:  `update variable(s) for a service`,
-		PreRunE: util.RunEChain(
-			util.NeedProjectContextWhenNonInteractive(f),
-			util.DefaultIDNameByContext(zctx.GetService(), &opts.id, &opts.name),
-			util.DefaultIDByContext(zctx.GetEnvironment(), &opts.environmentID),
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdateVariable(f, opts)
 		},
@@ -113,16 +107,24 @@ func runUpdateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runUpdateVariableNonInteractive(f *cmdutil.Factory, opts *Options) error {
-	zctx := f.Config.GetContext()
+	if opts.id == "" && opts.name != "" {
+		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
+		if err != nil {
+			return err
+		}
+		opts.id = service.ID
+	}
 
-	if _, err := f.ParamFiller.ServiceByNameWithEnvironment(fill.ServiceByNameWithEnvironmentOptions{
-		ProjectCtx:    zctx,
-		ServiceID:     &opts.id,
-		ServiceName:   &opts.name,
-		EnvironmentID: &opts.environmentID,
-		CreateNew:     false,
-	}); err != nil {
-		return err
+	if opts.id == "" {
+		return fmt.Errorf("--id or --name is required")
+	}
+
+	if opts.environmentID == "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return err
+		}
+		opts.environmentID = envID
 	}
 
 	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,

--- a/internal/util/env.go
+++ b/internal/util/env.go
@@ -22,7 +22,7 @@ func AddEnvOfServiceParam(cmd *cobra.Command, id *string) {
 // Every project has exactly one environment since environments are deprecated.
 func ResolveEnvironmentID(client api.Client, projectID string) (string, error) {
 	if projectID == "" {
-		return "", fmt.Errorf("project ID is required to resolve environment ID; please set project context with `zeabur context set project`")
+		return "", fmt.Errorf("project ID is required to resolve environment ID")
 	}
 
 	environments, err := client.ListEnvironments(context.Background(), projectID)
@@ -35,4 +35,17 @@ func ResolveEnvironmentID(client api.Client, projectID string) (string, error) {
 	}
 
 	return environments[0].ID, nil
+}
+
+// ResolveEnvironmentIDByServiceID fetches the service, finds its project,
+// and resolves the environment ID from that project.
+func ResolveEnvironmentIDByServiceID(client api.Client, serviceID string) (string, error) {
+	service, err := client.GetService(context.Background(), serviceID, "", "", "")
+	if err != nil {
+		return "", fmt.Errorf("get service failed: %w", err)
+	}
+	if service.Project == nil || service.Project.ID == "" {
+		return "", fmt.Errorf("service has no associated project")
+	}
+	return ResolveEnvironmentID(client, service.Project.ID)
 }

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -69,6 +69,7 @@ type (
 		GetDNSName(ctx context.Context, serviceID string) (string, error)
 		UpdateImageTag(ctx context.Context, serviceID string, environmentID string, tag string) error
 		DeleteService(ctx context.Context, id string, environmentID string) error
+		ExecuteCommand(ctx context.Context, serviceID string, environmentID string, command []string) (*model.CommandResult, error)
 	}
 
 	VariableAPI interface {

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -530,3 +530,20 @@ func (c *client) DeleteService(ctx context.Context, id string, environmentID str
 
 	return err
 }
+
+func (c *client) ExecuteCommand(ctx context.Context, serviceID string, environmentID string, command []string) (*model.CommandResult, error) {
+	var mutation struct {
+		ExecuteCommand model.CommandResult `graphql:"executeCommand(serviceID: $serviceID, environmentID: $environmentID, command: $command)"`
+	}
+
+	err := c.Mutate(ctx, &mutation, V{
+		"serviceID":     ObjectID(serviceID),
+		"environmentID": ObjectID(environmentID),
+		"command":       command,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &mutation.ExecuteCommand, nil
+}

--- a/pkg/model/command.go
+++ b/pkg/model/command.go
@@ -1,0 +1,7 @@
+package model
+
+// CommandResult represents the result of a command execution.
+type CommandResult struct {
+	ExitCode int    `graphql:"exitCode"`
+	Output   string `graphql:"output"`
+}


### PR DESCRIPTION
## Summary
- Add `zeabur service exec` command to run commands inside service containers via the `executeCommand` GraphQL mutation
- Remove context-based ID resolution from all commands — when a service ID is provided, environment and project IDs are now derived from the service itself instead of relying on project context
- Add `ResolveEnvironmentIDByServiceID` helper to `internal/util/env.go`

## Motivation
The old design resolved environment IDs from the project context, which could point to a completely different project than the service belongs to, causing `NOT_RUNNING_SERVICE` errors even when the service is active.

Now: service ID → fetch service → get project ID → resolve environment. No more wrong env IDs.

## Changed commands (32 files)
- **New**: `service exec` — execute commands in service containers
- **Service**: restart, redeploy, suspend, delete, expose, get, metric, instruction, network, update/tag, list, deploy
- **Domain**: create, list, delete
- **Variable**: create, list, update, delete, env
- **Deployment**: get, list, log
- **Other**: deploy, upload

## Test plan
- [ ] `go build ./...` and `go test ./...` pass
- [ ] `zeabur service exec --id <svc> -- ls` resolves env from service's project
- [ ] `zeabur service restart --id <svc>` no longer requires project context
- [ ] Interactive mode still prompts correctly when no flags provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `service exec` command to execute commands inside service containers with results and exit codes.
  * Added `--region` flag to template deployment for automatic project creation in specified regions.

* **Refactor**
  * Simplified command parameter resolution and validation for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->