### PR TITLE
feat: add `server list` command

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	domainCmd "github.com/zeabur/cli/internal/cmd/domain"
 	profileCmd "github.com/zeabur/cli/internal/cmd/profile"
 	projectCmd "github.com/zeabur/cli/internal/cmd/project"
+	serverCmd "github.com/zeabur/cli/internal/cmd/server"
 	serviceCmd "github.com/zeabur/cli/internal/cmd/service"
 	templateCmd "github.com/zeabur/cli/internal/cmd/template"
 	uploadCmd "github.com/zeabur/cli/internal/cmd/upload"
@@ -120,6 +121,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, commit, date string) (*cobra.Comman
 	cmd.AddCommand(versionCmd.NewCmdVersion(f, version, commit, date))
 	cmd.AddCommand(authCmd.NewCmdAuth(f))
 	cmd.AddCommand(projectCmd.NewCmdProject(f))
+	cmd.AddCommand(serverCmd.NewCmdServer(f))
 	cmd.AddCommand(serviceCmd.NewCmdService(f))
 	cmd.AddCommand(deploymentCmd.NewCmdDeployment(f))
 	cmd.AddCommand(templateCmd.NewCmdTemplate(f))

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -1,0 +1,35 @@
+package list
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zeabur/cli/internal/cmdutil"
+	"github.com/zeabur/cli/pkg/model"
+)
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List dedicated servers",
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(f)
+		},
+	}
+
+	return cmd
+}
+
+func runList(f *cmdutil.Factory) error {
+	servers, err := f.ApiClient.GetServers(context.Background())
+	if err != nil {
+		return err
+	}
+
+	s := model.Servers(servers)
+	f.Printer.Table(s.Header(), s.Rows())
+
+	return nil
+}

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -1,0 +1,22 @@
+// Package server contains the cmd for managing dedicated servers
+package server
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/zeabur/cli/internal/cmdutil"
+
+	serverListCmd "github.com/zeabur/cli/internal/cmd/server/list"
+)
+
+// NewCmdServer creates the server command
+func NewCmdServer(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Manage dedicated servers",
+	}
+
+	cmd.AddCommand(serverListCmd.NewCmdList(f))
+
+	return cmd
+}

--- a/pkg/model/server.go
+++ b/pkg/model/server.go
@@ -32,3 +32,24 @@ func (s Server) String() string {
 func (s Server) IsAvailable() bool {
 	return true
 }
+
+type Servers []Server
+
+func (s Servers) Header() []string {
+	return []string{"ID", "Name", "Location", "IP"}
+}
+
+func (s Servers) Rows() [][]string {
+	rows := make([][]string, len(s))
+	for i, server := range s {
+		location := server.IP
+		if server.Country != nil {
+			location = *server.Country
+			if server.City != nil {
+				location = fmt.Sprintf("%s, %s", *server.City, *server.Country)
+			}
+		}
+		rows[i] = []string{server.GetID(), server.Name, location, server.IP}
+	}
+	return rows
+}


### PR DESCRIPTION
## Summary
- Add `zeabur server list` command to list dedicated servers (ID, name, location, IP)
- Server IDs can be used with `--region server-<id>` when creating projects on dedicated servers
- Add `Servers` type with `Header()`/`Rows()` table methods to the model

## Test plan
- [x] Built CLI and ran `zeabur server list -i=false` — verified output shows dedicated servers
- [x] Used returned server ID to create a project on a dedicated server and deploy a template successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `server` command to manage dedicated servers
  * Added `server list` subcommand to view all dedicated servers with details including ID, name, location, and IP address in a table format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->