### PR TITLE
feat: poll server init events after rent and fix unit display

### DIFF
--- a/internal/cmd/server/rent/rent.go
+++ b/internal/cmd/server/rent/rent.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 	"github.com/zeabur/cli/internal/cmdutil"
 )
@@ -78,7 +80,13 @@ func runRentInteractive(f *cmdutil.Factory, opts *Options) error {
 
 		options := make([]string, len(regions))
 		for i, r := range regions {
-			options[i] = fmt.Sprintf("%s (%s, %s)", r.Name, r.City, r.Country)
+			if r.City != "" && r.Country != "" {
+				options[i] = fmt.Sprintf("%s (%s, %s)", r.Name, r.City, r.Country)
+			} else if r.Country != "" {
+				options[i] = fmt.Sprintf("%s (%s)", r.Name, r.Country)
+			} else {
+				options[i] = r.Name
+			}
 		}
 
 		idx, err := f.Prompter.Select("Select a region", "", options)
@@ -107,8 +115,8 @@ func runRentInteractive(f *cmdutil.Factory, opts *Options) error {
 			if p.GPU != nil {
 				gpu = fmt.Sprintf(", GPU: %s", *p.GPU)
 			}
-			options[i] = fmt.Sprintf("%s - %d CPU, %d MB RAM, %d GB Disk%s - $%.2f/mo%s",
-				p.Name, p.CPU, p.Memory, p.Disk, gpu, float64(p.Price)/100, available)
+			options[i] = fmt.Sprintf("%s - %d CPU, %d GB RAM, %d GB Disk%s - $%d/mo%s",
+				p.Name, p.CPU, p.Memory, p.Disk, gpu, p.Price, available)
 		}
 
 		idx, err := f.Prompter.Select("Select a plan", "", options)
@@ -160,7 +168,59 @@ func runRentNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	f.Log.Infof("Server rented successfully, ID: %s", serverID)
-	f.Log.Infof("The server is being provisioned. Use `zeabur server get %s` to check its status.", serverID)
+	f.Log.Infof("Waiting for server provisioning...")
 
-	return nil
+	return waitForServerInit(f, serverID)
+}
+
+func waitForServerInit(f *cmdutil.Factory, serverID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,
+		spinner.WithColor(cmdutil.SpinnerColor),
+		spinner.WithSuffix(" Initializing server..."),
+	)
+	s.Start()
+	defer s.Stop()
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	seenEvents := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("server provisioning timed out after 10 minutes, use `zeabur server get %s` to check status", serverID)
+		case <-ticker.C:
+		}
+
+		server, err := f.ApiClient.GetServer(ctx, serverID)
+		if err != nil {
+			continue
+		}
+
+		for i := seenEvents; i < len(server.Events); i++ {
+			ev := server.Events[i]
+			s.Stop()
+			f.Log.Infof("[%s] %s", ev.Severity, ev.Message)
+			s.Start()
+
+			if ev.Message == "Server initialized" {
+				s.Stop()
+				f.Log.Infof("Server is ready!")
+				return nil
+			}
+
+			if strings.HasPrefix(ev.Message, "Failed to rent server") {
+				s.Stop()
+				f.Log.Errorf("Server provisioning failed: %s", ev.Message)
+				f.Log.Infof("The charge has been refunded to your balance.")
+				return fmt.Errorf("server provisioning failed")
+			}
+		}
+		seenEvents = len(server.Events)
+
+		s.Suffix = fmt.Sprintf(" Initializing server... (%d events)", seenEvents)
+	}
 }

--- a/pkg/model/server.go
+++ b/pkg/model/server.go
@@ -83,11 +83,18 @@ type ServerDetail struct {
 	CreatedAt          time.Time           `graphql:"createdAt"`
 	Status             ServerStatus        `graphql:"status"`
 	ProviderInfo       *ServerProviderInfo `graphql:"providerInfo"`
+	Events             []ServerEvent       `graphql:"events"`
 }
 
 type ServerProviderInfo struct {
 	Code string `graphql:"code"`
 	Name string `graphql:"name"`
+}
+
+type ServerEvent struct {
+	Message  string    `graphql:"message"`
+	Time     time.Time `graphql:"time"`
+	Severity string    `graphql:"severity"`
 }
 
 func (s *ServerDetail) Header() []string {
@@ -190,11 +197,11 @@ func (p DedicatedServerPlans) Rows() [][]string {
 		rows[i] = []string{
 			plan.Name,
 			fmt.Sprintf("%d cores", plan.CPU),
-			fmt.Sprintf("%d MB", plan.Memory),
+			fmt.Sprintf("%d GB", plan.Memory),
 			fmt.Sprintf("%d GB", plan.Disk),
 			fmt.Sprintf("%d GB", plan.Egress),
 			gpu,
-			fmt.Sprintf("$%.2f", float64(plan.Price)/100),
+			fmt.Sprintf("$%d", plan.Price),
 			available,
 		}
 	}


### PR DESCRIPTION
## Summary

- After renting a server, CLI now polls server events every 2s to show provisioning progress in real-time (like the dashboard's `ServerInitStepsModal`)
  - Success: detects `"Server initialized"` event
  - Failure: detects `"Failed to rent server"` with refund notice
  - Timeout: 10 minutes with spinner
- Fix price display: API returns dollars, not cents (`$2/mo` not `$0.02/mo`)
- Fix memory display: API returns GB, not MB (`2 GB` not `2 MB`)
- Fix region selector: hide empty city/country instead of showing `(, )`

## Test plan

- [ ] `go run ./cmd/main.go server rent` — interactive flow shows correct units
- [ ] Region selector shows clean labels (no `(, )` for providers without city/country)
- [ ] After confirming rent, spinner + events stream appears until initialized or failed
- [ ] `go run ./cmd/main.go server rent --provider hetzner --region fsn1 --plan CAX11 -y -i=false` — non-interactive also polls events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual feedback during server initialization with automatic status polling and timeout protection.

* **Improvements**
  * Enhanced server plan display showing memory in GB with consistent CPU, RAM, and disk formatting.
  * Improved region selection interface with better city and country data presentation.
  * More informative provisioning failure messages and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->