### PR TITLE
feat: add `server ssh` command

### DIFF
--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -11,6 +11,7 @@ import (
 	serverRebootCmd "github.com/zeabur/cli/internal/cmd/server/reboot"
 	serverRegionCmd "github.com/zeabur/cli/internal/cmd/server/region"
 	serverRentCmd "github.com/zeabur/cli/internal/cmd/server/rent"
+	serverSSHCmd "github.com/zeabur/cli/internal/cmd/server/ssh"
 	"github.com/zeabur/cli/internal/cmdutil"
 )
 
@@ -28,6 +29,7 @@ func NewCmdServer(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(serverProviderCmd.NewCmdProvider(f))
 	cmd.AddCommand(serverRegionCmd.NewCmdRegion(f))
 	cmd.AddCommand(serverPlanCmd.NewCmdPlan(f))
+	cmd.AddCommand(serverSSHCmd.NewCmdSSH(f))
 
 	return cmd
 }

--- a/internal/cmd/server/ssh/ssh.go
+++ b/internal/cmd/server/ssh/ssh.go
@@ -1,0 +1,134 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+)
+
+type Options struct {
+	id string
+}
+
+func NewCmdSSH(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "ssh [server-id]",
+		Short: "SSH into a dedicated server",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				if opts.id != "" && opts.id != args[0] {
+					return fmt.Errorf("conflicting server IDs: arg=%q, --id=%q", args[0], opts.id)
+				}
+				opts.id = args[0]
+			}
+			return runSSH(f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.id, "id", "", "Server ID")
+
+	return cmd
+}
+
+func runSSH(f *cmdutil.Factory, opts *Options) error {
+	if f.Interactive {
+		return runSSHInteractive(f, opts)
+	}
+	return runSSHNonInteractive(f, opts)
+}
+
+func runSSHInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.id == "" {
+		servers, err := f.ApiClient.ListServers(context.Background())
+		if err != nil {
+			return fmt.Errorf("list servers failed: %w", err)
+		}
+		if len(servers) == 0 {
+			return fmt.Errorf("no servers found")
+		}
+
+		options := make([]string, len(servers))
+		for i, s := range servers {
+			location := s.IP
+			if s.City != nil && s.Country != nil {
+				location = fmt.Sprintf("%s, %s", *s.City, *s.Country)
+			} else if s.Country != nil {
+				location = *s.Country
+			}
+			options[i] = fmt.Sprintf("%s (%s)", s.Name, location)
+		}
+
+		idx, err := f.Prompter.Select("Select a server", "", options)
+		if err != nil {
+			return err
+		}
+		opts.id = servers[idx].ID
+	}
+
+	return runSSHNonInteractive(f, opts)
+}
+
+func runSSHNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.id == "" {
+		return fmt.Errorf("--id is required")
+	}
+
+	ctx := context.Background()
+
+	server, err := f.ApiClient.GetServer(ctx, opts.id)
+	if err != nil {
+		return fmt.Errorf("get server failed: %w", err)
+	}
+
+	username := "root"
+	if server.SSHUsername != nil && *server.SSHUsername != "" {
+		username = *server.SSHUsername
+	}
+
+	// Try to get password for managed servers
+	var password string
+	if server.IsManaged {
+		pw, err := f.ApiClient.RevealServerPassword(ctx, opts.id)
+		if err == nil && pw != "" {
+			password = pw
+		}
+	}
+
+	sshArgs := []string{
+		fmt.Sprintf("%s@%s", username, server.IP),
+		"-p", strconv.Itoa(server.SSHPort),
+		"-o", "StrictHostKeyChecking=no",
+	}
+
+	f.Log.Infof("Connecting to %s@%s:%d ...", username, server.IP, server.SSHPort)
+
+	if password != "" {
+		sshpassPath, err := exec.LookPath("sshpass")
+		if err == nil {
+			// Use sshpass for automatic password authentication
+			sshCmd := exec.Command(sshpassPath, append([]string{"-p", password, "ssh"}, sshArgs...)...)
+			sshCmd.Stdin = os.Stdin
+			sshCmd.Stdout = os.Stdout
+			sshCmd.Stderr = os.Stderr
+			return sshCmd.Run()
+		}
+		// sshpass not available, show password to user
+		f.Log.Infof("Password: %s", password)
+		f.Log.Infof("(Install sshpass for automatic login)")
+	}
+
+	sshCmd := exec.Command("ssh", sshArgs...)
+	sshCmd.Stdin = os.Stdin
+	sshCmd.Stdout = os.Stdout
+	sshCmd.Stderr = os.Stderr
+
+	return sshCmd.Run()
+}

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -51,6 +51,7 @@ type (
 		ListDedicatedServerRegions(ctx context.Context, provider string) ([]model.DedicatedServerRegion, error)
 		ListDedicatedServerPlans(ctx context.Context, provider, region string) (model.DedicatedServerPlans, error)
 		RentServer(ctx context.Context, provider, region, plan string) (string, error)
+		RevealServerPassword(ctx context.Context, serverID string) (string, error)
 	}
 
 	EnvironmentAPI interface {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -114,3 +114,18 @@ func (c *client) RentServer(ctx context.Context, provider, region, plan string) 
 
 	return mutation.RentServer.ID, nil
 }
+
+func (c *client) RevealServerPassword(ctx context.Context, serverID string) (string, error) {
+	var mutation struct {
+		Password string `graphql:"revealManagedServerInitialPassword(serverID: $serverID)"`
+	}
+
+	err := c.Mutate(ctx, &mutation, V{
+		"serverID": ObjectID(serverID),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return mutation.Password, nil
+}


### PR DESCRIPTION
## Summary

- Add `zeabur server ssh [server-id]` command to SSH into dedicated servers
- For managed servers, auto-fetches password via `revealManagedServerInitialPassword` API
- Uses `sshpass` for automatic login if available; otherwise prints the password for manual entry
- Interactive mode: select server from list; non-interactive: pass server ID as arg or `--id`

## Test plan

- [ ] `go run ./cmd/main.go server ssh` — interactive server selection then SSH
- [ ] `go run ./cmd/main.go server ssh <id>` — direct SSH with auto password
- [ ] Without `sshpass` installed: password is printed, user pastes it at prompt
- [ ] With `sshpass` installed: login is fully automatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new SSH command for connecting to managed servers with support for interactive server selection
  * Enabled automated authentication using managed server credentials and sshpass integration
  * Added password reveal functionality for manual server access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->