### PR TITLE
fix: branch selection not captured when multiple branches exist in service deploy

### DIFF
--- a/internal/cmd/service/deploy/deploy.go
+++ b/internal/cmd/service/deploy/deploy.go
@@ -39,7 +39,6 @@ func NewCmdDeploy(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVar(&opts.repoID, "repo-id", 0, "Git repository ID")
 	cmd.Flags().StringVar(&opts.branchName, "branch-name", "", "Git branch name")
 	cmd.Flags().StringVar(&opts.keyword, "keyword", "", "Git repository keyword")
-
 	return cmd
 }
 
@@ -197,10 +196,11 @@ func runDeployInteractive(f *cmdutil.Factory, opts *Options) error {
 		if len(branches) == 1 {
 			opts.branchName = branches[0]
 		} else {
-			_, err = f.Prompter.Select("Select branch", opts.branchName, branches)
+			branchIndex, err := f.Prompter.Select("Select branch", opts.branchName, branches)
 			if err != nil {
 				return err
 			}
+			opts.branchName = branches[branchIndex]
 		}
 
 		s = spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -334,7 +334,7 @@ func (c *client) SearchGitRepositories(ctx context.Context, keyword *string) ([]
 
 func (c *client) CreateService(ctx context.Context, projectID string, name string, repoID int, branchName string) (*model.Service, error) {
 	var mutation struct {
-		CreateService model.Service `graphql:"createService(projectID: $projectID, template: $template, name: $name, gitProvider: $gitProvider repoID: $repoID, branchName: $branchName)"`
+		CreateService model.Service `graphql:"createService(projectID: $projectID, template: $template, name: $name, gitProvider: $gitProvider, repoID: $repoID, branchName: $branchName)"`
 	}
 
 	err := c.Mutate(ctx, &mutation, V{


### PR DESCRIPTION
## Summary
- Fix branch selection bug where selected index was discarded when multiple branches exist in interactive `service deploy --template GIT`

## Test plan
- [ ] Test `service deploy --template GIT` in interactive mode with a repo that has multiple branches
- [ ] Verify the correct branch is passed to `CreateService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed branch selection during interactive deployment to properly use the selected branch instead of ignoring the user's choice.
  * Corrected GraphQL syntax in service creation mutation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->