### PR TITLE
feat(service): add port-forward command and enhance network info

### DIFF
--- a/internal/cmd/service/network/network.go
+++ b/internal/cmd/service/network/network.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zeabur/cli/internal/cmdutil"
 	"github.com/zeabur/cli/internal/util"
 	"github.com/zeabur/cli/pkg/fill"
+	"github.com/zeabur/cli/pkg/model"
 )
 
 type Options struct {
@@ -68,19 +69,81 @@ func runNetwork(f *cmdutil.Factory, opts *Options) error {
 	)
 	s.Start()
 
-	dnsName, err := f.ApiClient.GetDNSName(context.Background(), opts.id)
+	ctx := context.Background()
+
+	dnsName, err := f.ApiClient.GetDNSName(ctx, opts.id)
 	if err != nil {
 		s.Stop()
 		return err
 	}
 
+	// Fetch port forwarding info if environmentID is available
+	var portForwardingMode model.PortForwardingMode
+	var ports []model.ServicePort
+	var portForwardedHost string
+
+	if opts.environmentID != "" {
+		portForwardingMode, err = f.ApiClient.GetPortForwardingMode(ctx, opts.id, opts.environmentID)
+		if err != nil {
+			s.Stop()
+			return err
+		}
+
+		if portForwardingMode == model.PortForwardingModeEnabled {
+			ports, err = f.ApiClient.GetServicePorts(ctx, opts.id, opts.environmentID)
+			if err != nil {
+				s.Stop()
+				return err
+			}
+
+			portForwardedHost, err = f.ApiClient.GetPortForwardedHost(ctx, opts.id)
+			if err != nil {
+				s.Stop()
+				return err
+			}
+		}
+	}
+
 	s.Stop()
 
 	if f.JSON {
-		return f.Printer.JSON(map[string]string{"dnsName": dnsName + ".zeabur.internal"})
+		result := map[string]interface{}{
+			"dnsName": dnsName + ".zeabur.internal",
+		}
+		if opts.environmentID != "" {
+			result["portForwardingMode"] = string(portForwardingMode)
+			if portForwardingMode == model.PortForwardingModeEnabled {
+				result["portForwardedHost"] = portForwardedHost
+				portList := make([]map[string]interface{}, 0, len(ports))
+				for _, p := range ports {
+					pm := map[string]interface{}{
+						"id":   p.ID,
+						"port": p.Port,
+						"type": p.Type,
+					}
+					if p.ForwardedPort != nil {
+						pm["forwardedPort"] = *p.ForwardedPort
+					}
+					portList = append(portList, pm)
+				}
+				result["ports"] = portList
+			}
+		}
+		return f.Printer.JSON(result)
 	}
 
 	f.Log.Infof("Private DNS name for %s: %s", opts.name, dnsName+".zeabur.internal")
+
+	if opts.environmentID != "" {
+		f.Log.Infof("Port forwarding: %s", portForwardingMode)
+		if portForwardingMode == model.PortForwardingModeEnabled && portForwardedHost != "" {
+			for _, p := range ports {
+				if p.ForwardedPort != nil && (p.Type == "TCP" || p.Type == "UDP") {
+					f.Log.Infof("  %s (%s %d) → %s:%d", p.ID, p.Type, p.Port, portForwardedHost, *p.ForwardedPort)
+				}
+			}
+		}
+	}
 
 	return nil
 }

--- a/internal/cmd/service/port-forward/port_forward.go
+++ b/internal/cmd/service/port-forward/port_forward.go
@@ -1,0 +1,186 @@
+package portforward
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+	"github.com/zeabur/cli/internal/util"
+	"github.com/zeabur/cli/pkg/fill"
+	"github.com/zeabur/cli/pkg/model"
+)
+
+type Options struct {
+	id            string
+	name          string
+	environmentID string
+
+	enable  bool
+	disable bool
+}
+
+func NewCmdPortForward(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "port-forward",
+		Short: "Manage port forwarding for a service",
+		Long: `Manage port forwarding for a service.
+example:
+      zeabur service port-forward                              # show status (interactive)
+      zeabur service port-forward --enable                     # enable
+      zeabur service port-forward --disable                    # disable
+      zeabur service port-forward --id SERVICE_ID --enable     # non-interactive
+`,
+		Aliases: []string{"pf"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPortForward(f, opts)
+		},
+	}
+
+	util.AddServiceParam(cmd, &opts.id, &opts.name)
+	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
+	cmd.Flags().BoolVar(&opts.enable, "enable", false, "Enable port forwarding")
+	cmd.Flags().BoolVar(&opts.disable, "disable", false, "Disable port forwarding")
+
+	return cmd
+}
+
+func runPortForward(f *cmdutil.Factory, opts *Options) error {
+	if opts.enable && opts.disable {
+		return fmt.Errorf("cannot use both --enable and --disable")
+	}
+
+	if f.Interactive {
+		return runPortForwardInteractive(f, opts)
+	}
+	return runPortForwardNonInteractive(f, opts)
+}
+
+func runPortForwardInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.id == "" && opts.name == "" {
+		zctx := f.Config.GetContext()
+		if _, err := f.ParamFiller.ServiceByNameWithEnvironment(fill.ServiceByNameWithEnvironmentOptions{
+			ProjectCtx:    zctx,
+			ServiceID:     &opts.id,
+			ServiceName:   &opts.name,
+			EnvironmentID: &opts.environmentID,
+			CreateNew:     false,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return runPortForwardNonInteractive(f, opts)
+}
+
+func runPortForwardNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.id == "" && opts.name != "" {
+		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
+		if err != nil {
+			return err
+		}
+		opts.id = service.ID
+	}
+
+	if opts.id == "" {
+		return fmt.Errorf("service id or name is required")
+	}
+
+	if opts.environmentID == "" {
+		return fmt.Errorf("environment id is required (use --env-id or select interactively)")
+	}
+
+	ctx := context.Background()
+
+	// If --enable or --disable, update the mode
+	if opts.enable || opts.disable {
+		mode := model.PortForwardingModeEnabled
+		if opts.disable {
+			mode = model.PortForwardingModeDisabled
+		}
+
+		s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,
+			spinner.WithColor(cmdutil.SpinnerColor),
+			spinner.WithSuffix(fmt.Sprintf(" Updating port forwarding mode to %s ...", mode)),
+		)
+		s.Start()
+
+		err := f.ApiClient.UpdatePortForwardingMode(ctx, opts.id, opts.environmentID, mode)
+		s.Stop()
+		if err != nil {
+			return fmt.Errorf("failed to update port forwarding mode: %w", err)
+		}
+
+		f.Log.Infof("Port forwarding mode updated to %s", mode)
+		return nil
+	}
+
+	// Otherwise, show current status
+	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,
+		spinner.WithColor(cmdutil.SpinnerColor),
+		spinner.WithSuffix(" Fetching port forwarding status ..."),
+	)
+	s.Start()
+
+	mode, err := f.ApiClient.GetPortForwardingMode(ctx, opts.id, opts.environmentID)
+	if err != nil {
+		s.Stop()
+		return err
+	}
+
+	var ports []model.ServicePort
+	var host string
+
+	if mode == model.PortForwardingModeEnabled {
+		ports, err = f.ApiClient.GetServicePorts(ctx, opts.id, opts.environmentID)
+		if err != nil {
+			s.Stop()
+			return err
+		}
+
+		host, err = f.ApiClient.GetPortForwardedHost(ctx, opts.id)
+		if err != nil {
+			s.Stop()
+			return err
+		}
+	}
+
+	s.Stop()
+
+	if f.JSON {
+		result := map[string]interface{}{
+			"portForwardingMode": string(mode),
+		}
+		if mode == model.PortForwardingModeEnabled {
+			result["portForwardedHost"] = host
+			portList := make([]map[string]interface{}, 0, len(ports))
+			for _, p := range ports {
+				pm := map[string]interface{}{
+					"id":   p.ID,
+					"port": p.Port,
+					"type": p.Type,
+				}
+				if p.ForwardedPort != nil {
+					pm["forwardedPort"] = *p.ForwardedPort
+				}
+				portList = append(portList, pm)
+			}
+			result["ports"] = portList
+		}
+		return f.Printer.JSON(result)
+	}
+
+	f.Log.Infof("Port forwarding: %s", mode)
+	if mode == model.PortForwardingModeEnabled && host != "" {
+		for _, p := range ports {
+			if p.ForwardedPort != nil && (p.Type == "TCP" || p.Type == "UDP") {
+				f.Log.Infof("  %s (%s %d) → %s:%d", p.ID, p.Type, p.Port, host, *p.ForwardedPort)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/cmd/service/service.go
+++ b/internal/cmd/service/service.go
@@ -13,6 +13,7 @@ import (
 	serviceListCmd "github.com/zeabur/cli/internal/cmd/service/list"
 	serviceMetricCmd "github.com/zeabur/cli/internal/cmd/service/metric"
 	serviceNetworkCmd "github.com/zeabur/cli/internal/cmd/service/network"
+	servicePortForwardCmd "github.com/zeabur/cli/internal/cmd/service/port-forward"
 	serviceRedeployCmd "github.com/zeabur/cli/internal/cmd/service/redeploy"
 	serviceRestartCmd "github.com/zeabur/cli/internal/cmd/service/restart"
 	serviceSuspendCmd "github.com/zeabur/cli/internal/cmd/service/suspend"
@@ -40,6 +41,7 @@ func NewCmdService(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(serviceExecCmd.NewCmdExec(f))
 	cmd.AddCommand(serviceInstructionCmd.NewCmdInstruction(f))
 	cmd.AddCommand(serviceNetworkCmd.NewCmdPrivateNetwork(f))
+	cmd.AddCommand(servicePortForwardCmd.NewCmdPortForward(f))
 	cmd.AddCommand(serviceUpdateCmd.NewCmdUpdate(f))
 
 	return cmd

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -84,6 +84,10 @@ type (
 		CreateEmptyService(ctx context.Context, projectID string, name string) (*model.Service, error)
 		UploadZipToService(ctx context.Context, projectID string, serviceID string, environmentID string, zipBytes []byte) (*model.Service, error)
 		GetDNSName(ctx context.Context, serviceID string) (string, error)
+		GetPortForwardingMode(ctx context.Context, serviceID string, environmentID string) (model.PortForwardingMode, error)
+		UpdatePortForwardingMode(ctx context.Context, serviceID string, environmentID string, mode model.PortForwardingMode) error
+		GetServicePorts(ctx context.Context, serviceID string, environmentID string) ([]model.ServicePort, error)
+		GetPortForwardedHost(ctx context.Context, serviceID string) (string, error)
 		UpdateImageTag(ctx context.Context, serviceID string, environmentID string, tag string) error
 		DeleteService(ctx context.Context, id string, environmentID string) error
 		ExecuteCommand(ctx context.Context, serviceID string, environmentID string, command []string) (*model.CommandResult, error)

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -501,6 +501,64 @@ func (c *client) GetDNSName(ctx context.Context, serviceID string) (string, erro
 	return query.Service.DnsName, nil
 }
 
+func (c *client) GetPortForwardingMode(ctx context.Context, serviceID string, environmentID string) (model.PortForwardingMode, error) {
+	var query struct {
+		Service struct {
+			PortForwardingMode model.PortForwardingMode `graphql:"portForwardingMode(environmentID: $environmentID)"`
+		} `graphql:"service(_id: $serviceID)"`
+	}
+	err := c.Query(ctx, &query, V{
+		"serviceID":     ObjectID(serviceID),
+		"environmentID": ObjectID(environmentID),
+	})
+	if err != nil {
+		return "", err
+	}
+	return query.Service.PortForwardingMode, nil
+}
+
+func (c *client) UpdatePortForwardingMode(ctx context.Context, serviceID string, environmentID string, mode model.PortForwardingMode) error {
+	var mutation struct {
+		UpdatePortForwardingMode bool `graphql:"updatePortForwardingMode(serviceID: $serviceID, environmentID: $environmentID, mode: $mode)"`
+	}
+	return c.Mutate(ctx, &mutation, V{
+		"serviceID":     ObjectID(serviceID),
+		"environmentID": ObjectID(environmentID),
+		"mode":          mode,
+	})
+}
+
+func (c *client) GetServicePorts(ctx context.Context, serviceID string, environmentID string) ([]model.ServicePort, error) {
+	var query struct {
+		Service struct {
+			Ports []model.ServicePort `graphql:"ports(environmentID: $environmentID)"`
+		} `graphql:"service(_id: $serviceID)"`
+	}
+	err := c.Query(ctx, &query, V{
+		"serviceID":     ObjectID(serviceID),
+		"environmentID": ObjectID(environmentID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return query.Service.Ports, nil
+}
+
+func (c *client) GetPortForwardedHost(ctx context.Context, serviceID string) (string, error) {
+	var query struct {
+		Service struct {
+			PortForwardedHost string `graphql:"portForwardedHost"`
+		} `graphql:"service(_id: $serviceID)"`
+	}
+	err := c.Query(ctx, &query, V{
+		"serviceID": ObjectID(serviceID),
+	})
+	if err != nil {
+		return "", err
+	}
+	return query.Service.PortForwardedHost, nil
+}
+
 func (c *client) UpdateImageTag(ctx context.Context, serviceID, environmentID, tag string) error {
 	var mutation struct {
 		UpdateImageTag bool `graphql:"updateServiceImage(serviceID: $serviceID, environmentID: $environmentID, tag: $tag)"`

--- a/pkg/model/service.go
+++ b/pkg/model/service.go
@@ -180,6 +180,28 @@ func formatFloat64(v float64) string {
 	return strconv.FormatFloat(v, 'f', 6, 64)
 }
 
+// PortForwardingMode is the mode of port forwarding.
+type PortForwardingMode string
+
+// valid port forwarding modes
+const (
+	PortForwardingModeEnabled  PortForwardingMode = "ENABLED"
+	PortForwardingModeDisabled PortForwardingMode = "DISABLED"
+	PortForwardingModeUnknown  PortForwardingMode = "UNKNOWN"
+)
+
+func (m PortForwardingMode) GetGraphQLType() string {
+	return "PortForwardingMode"
+}
+
+// ServicePort represents a port of a service.
+type ServicePort struct {
+	ID            string `graphql:"id" json:"id"`
+	Port          int    `graphql:"port" json:"port"`
+	Type          string `graphql:"type" json:"type"`
+	ForwardedPort *int   `graphql:"forwardedPort" json:"forwardedPort"`
+}
+
 type ServiceTemplate string
 
 const (


### PR DESCRIPTION
## Summary

- **New `service port-forward` subcommand**: Query and manage port forwarding mode (enable/disable) for services, with both interactive and non-interactive support.
- **Enhanced `service network` output**: Now also displays port forwarding status and forwarded port mappings (e.g., `hostname:forwardedPort`) when environment ID is available.
- **New models and API methods**: Added `PortForwardingMode`, `ServicePort` models and four API client methods (`GetPortForwardingMode`, `UpdatePortForwardingMode`, `GetServicePorts`, `GetPortForwardedHost`).

Previously, users had to use the Dashboard to query or manage port forwarding. This PR brings that capability to the CLI.

## Test plan

- [ ] Run `zeabur service port-forward` interactively to verify service/environment selection and status display
- [ ] Run `zeabur service port-forward --id <id> --env-id <env> --enable` to enable port forwarding
- [ ] Run `zeabur service port-forward --id <id> --env-id <env> --disable` to disable port forwarding
- [ ] Run `zeabur service network` and verify port forwarding info is shown alongside private DNS name
- [ ] Verify `--json` output includes port forwarding fields for both commands
- [ ] Verify `go build ./...` and `go vet ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- **Port Forwarding Management**: New CLI command enables users to manage service port forwarding—enable/disable forwarding per environment with status visibility.
- **Enhanced Service Information**: Service details now display comprehensive port forwarding status, including individual port mappings, forwarded ports, and target hosts.
- **JSON Output Support**: Port forwarding configuration and status data available in JSON format for programmatic access and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->