### PR TITLE
fix(service): auto-resolve environmentID in network and port-forward

### DIFF
--- a/internal/cmd/service/network/network.go
+++ b/internal/cmd/service/network/network.go
@@ -63,6 +63,14 @@ func runNetwork(f *cmdutil.Factory, opts *Options) error {
 		return fmt.Errorf("service id or name is required")
 	}
 
+	// Auto-resolve environmentID if not provided
+	if opts.environmentID == "" {
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err == nil {
+			opts.environmentID = envID
+		}
+	}
+
 	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,
 		spinner.WithColor(cmdutil.SpinnerColor),
 		spinner.WithSuffix(fmt.Sprintf(" Fetching network information of service %s ...", opts.name)),

--- a/internal/cmd/service/port-forward/port_forward.go
+++ b/internal/cmd/service/port-forward/port_forward.go
@@ -89,8 +89,13 @@ func runPortForwardNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		return fmt.Errorf("service id or name is required")
 	}
 
+	// Auto-resolve environmentID if not provided
 	if opts.environmentID == "" {
-		return fmt.Errorf("environment id is required (use --env-id or select interactively)")
+		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
+		if err != nil {
+			return fmt.Errorf("environment id is required (use --env-id or select interactively)")
+		}
+		opts.environmentID = envID
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- `service network` and `service port-forward` both required `--env-id` in non-interactive mode
- Every project has exactly one environment (environments are deprecated), so we can auto-resolve it from the service ID
- Uses existing `util.ResolveEnvironmentIDByServiceID` that other commands already use (expose, restart, etc.)

## Before

```bash
zeabur service network --id SERVICE_ID -i=false
# Only shows dnsName, no port forwarding info

zeabur service port-forward --id SERVICE_ID -i=false
# ERROR: environment id is required
```

## After

```bash
zeabur service network --id SERVICE_ID -i=false
# Shows dnsName + port forwarding mode + forwarded host:port

zeabur service port-forward --id SERVICE_ID -i=false
# Shows port forwarding status with forwarded endpoints
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment ID is now automatically resolved from the service ID when not explicitly provided, improving the user experience by reducing manual configuration requirements and streamlining the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->