### PR TITLE
feat: add domain registrant verification commands

### DIFF
--- a/internal/cmd/domain/domain.go
+++ b/internal/cmd/domain/domain.go
@@ -14,6 +14,7 @@ import (
 	registrantCmd "github.com/zeabur/cli/internal/cmd/domain/registrant"
 	renewCmd "github.com/zeabur/cli/internal/cmd/domain/renew"
 	searchCmd "github.com/zeabur/cli/internal/cmd/domain/search"
+	verificationCmd "github.com/zeabur/cli/internal/cmd/domain/verification"
 	"github.com/zeabur/cli/internal/cmdutil"
 )
 
@@ -39,6 +40,7 @@ func NewCmdDomain(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(autoRenewCmd.NewCmdAutoRenew(f))
 	cmd.AddCommand(dnsCmd.NewCmdDNS(f))
 	cmd.AddCommand(registrantCmd.NewCmdRegistrant(f))
+	cmd.AddCommand(verificationCmd.NewCmdVerification(f))
 
 	return cmd
 }

--- a/internal/cmd/domain/verification/verification.go
+++ b/internal/cmd/domain/verification/verification.go
@@ -1,0 +1,82 @@
+package verification
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+)
+
+func NewCmdVerification(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verification",
+		Short: "Manage registrant verification for registered domains",
+	}
+
+	cmd.AddCommand(newCmdResend(f))
+
+	return cmd
+}
+
+type resendOptions struct {
+	id string
+}
+
+func newCmdResend(f *cmdutil.Factory) *cobra.Command {
+	opts := &resendOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "resend",
+		Short: "Resend the ICANN registrant verification email",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResend(f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.id, "id", "", "Registered domain ID")
+
+	return cmd
+}
+
+func runResend(f *cmdutil.Factory, opts *resendOptions) error {
+	ctx := context.Background()
+
+	if opts.id == "" {
+		if !f.Interactive {
+			return fmt.Errorf("--id is required")
+		}
+		domains, err := f.ApiClient.ListRegisteredDomains(ctx)
+		if err != nil {
+			return fmt.Errorf("list registered domains failed: %w", err)
+		}
+		if len(domains) == 0 {
+			return fmt.Errorf("no registered domains found")
+		}
+
+		options := make([]string, len(domains))
+		for i, d := range domains {
+			options[i] = d.Domain
+		}
+		idx, err := f.Prompter.Select("Select domain to resend verification email", "", options)
+		if err != nil {
+			return err
+		}
+		opts.id = domains[idx].ID
+	}
+
+	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,
+		spinner.WithColor(cmdutil.SpinnerColor),
+		spinner.WithSuffix(" Resending verification email..."),
+	)
+	s.Start()
+	err := f.ApiClient.ResendRegistrantVerificationEmail(ctx, opts.id)
+	s.Stop()
+	if err != nil {
+		return fmt.Errorf("resend verification email failed: %w", err)
+	}
+
+	f.Log.Infof("Verification email resent successfully")
+	return nil
+}

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -173,6 +173,9 @@ type (
 		CreateRegistrantProfile(ctx context.Context, input model.CreateRegistrantProfileInput) (*model.RegistrantProfile, error)
 		UpdateRegistrantProfile(ctx context.Context, id string, input model.UpdateRegistrantProfileInput) (*model.RegistrantProfile, error)
 		DeleteRegistrantProfile(ctx context.Context, id string) error
+
+		ResendRegistrantVerificationEmail(ctx context.Context, registeredDomainID string) error
+		UpdateRegistrantContact(ctx context.Context, registeredDomainID string, input model.UpdateRegistrantContactInput) error
 	}
 
 	ZSendAPI interface {

--- a/pkg/api/registered_domain.go
+++ b/pkg/api/registered_domain.go
@@ -204,6 +204,31 @@ func (c *client) UpdateRegistrantProfile(ctx context.Context, id string, input m
 	return &mutation.UpdateRegistrantProfile, nil
 }
 
+func (c *client) ResendRegistrantVerificationEmail(ctx context.Context, registeredDomainID string) error {
+	var mutation struct {
+		ResendRegistrantVerificationEmail bool `graphql:"resendRegistrantVerificationEmail(registeredDomainID: $registeredDomainID)"`
+	}
+
+	err := c.Mutate(ctx, &mutation, V{
+		"registeredDomainID": ObjectID(registeredDomainID),
+	})
+
+	return err
+}
+
+func (c *client) UpdateRegistrantContact(ctx context.Context, registeredDomainID string, input model.UpdateRegistrantContactInput) error {
+	var mutation struct {
+		UpdateRegistrantContact bool `graphql:"updateRegistrantContact(registeredDomainID: $registeredDomainID, input: $input)"`
+	}
+
+	err := c.Mutate(ctx, &mutation, V{
+		"registeredDomainID": ObjectID(registeredDomainID),
+		"input":              input,
+	})
+
+	return err
+}
+
 func (c *client) DeleteRegistrantProfile(ctx context.Context, id string) error {
 	var mutation struct {
 		DeleteRegistrantProfile bool `graphql:"deleteRegistrantProfile(id: $id)"`

--- a/pkg/model/registered_domain.go
+++ b/pkg/model/registered_domain.go
@@ -6,15 +6,16 @@ import (
 )
 
 type RegisteredDomain struct {
-	ID            string    `json:"_id" graphql:"_id"`
-	Domain        string    `json:"domain" graphql:"domain"`
-	TLD           string    `json:"tld" graphql:"tld"`
-	Status        string    `json:"status" graphql:"status"`
-	AutoRenew     bool      `json:"autoRenew" graphql:"autoRenew"`
-	ExpiresAt     time.Time `json:"expiresAt" graphql:"expiresAt"`
-	RegisteredAt  time.Time `json:"registeredAt" graphql:"registeredAt"`
-	PurchasePrice int       `json:"purchasePrice" graphql:"purchasePrice"`
-	RenewalPrice  int       `json:"renewalPrice" graphql:"renewalPrice"`
+	ID                           string    `json:"_id" graphql:"_id"`
+	Domain                       string    `json:"domain" graphql:"domain"`
+	TLD                          string    `json:"tld" graphql:"tld"`
+	Status                       string    `json:"status" graphql:"status"`
+	AutoRenew                    bool      `json:"autoRenew" graphql:"autoRenew"`
+	ExpiresAt                    time.Time `json:"expiresAt" graphql:"expiresAt"`
+	RegisteredAt                 time.Time `json:"registeredAt" graphql:"registeredAt"`
+	PurchasePrice                int       `json:"purchasePrice" graphql:"purchasePrice"`
+	RenewalPrice                 int       `json:"renewalPrice" graphql:"renewalPrice"`
+	RegistrantVerificationStatus *string   `json:"registrantVerificationStatus" graphql:"registrantVerificationStatus"`
 }
 
 func (d RegisteredDomain) Header() []string {
@@ -192,6 +193,20 @@ type UpdateRegistrantProfileInput struct {
 	State        *string `json:"state,omitempty" graphql:"state"`
 	Country      *string `json:"country,omitempty" graphql:"country"`
 	PostalCode   *string `json:"postalCode,omitempty" graphql:"postalCode"`
+	Organization *string `json:"organization,omitempty" graphql:"organization"`
+}
+
+type UpdateRegistrantContactInput struct {
+	FirstName    string  `json:"firstName" graphql:"firstName"`
+	LastName     string  `json:"lastName" graphql:"lastName"`
+	Email        string  `json:"email" graphql:"email"`
+	Phone        string  `json:"phone" graphql:"phone"`
+	Address1     string  `json:"address1" graphql:"address1"`
+	Address2     *string `json:"address2,omitempty" graphql:"address2"`
+	City         string  `json:"city" graphql:"city"`
+	State        string  `json:"state" graphql:"state"`
+	Country      string  `json:"country" graphql:"country"`
+	PostalCode   string  `json:"postalCode" graphql:"postalCode"`
 	Organization *string `json:"organization,omitempty" graphql:"organization"`
 }
 


### PR DESCRIPTION
## Summary

Add CLI support for ICANN registrant verification, complementing the backend changes in zeabur/backend#1766.

### New Command
- `zeabur domain verification resend --id <domain-id>` — Resend the ICANN registrant verification email

### New API Methods
- `ResendRegistrantVerificationEmail` — calls the new GraphQL mutation
- `UpdateRegistrantContact` — calls the admin-only mutation for fixing wrong emails

### Model Changes
- `RegisteredDomain.RegistrantVerificationStatus` field added
- `UpdateRegistrantContactInput` type added

## Test plan
- [ ] `go build ./...` ✅
- [ ] `zeabur domain verification resend` — interactive mode lists domains
- [ ] `zeabur domain verification resend --id <id> -i=false` — non-interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added verification subcommand to domain management for handling registrant verification workflows
  * Users can resend ICANN registrant verification emails by specifying a domain ID or selecting from available domains in interactive mode
  * Added capability to track registrant verification status and update registrant contact information for registered domains

<!-- end of auto-generated comment: release notes by coderabbit.ai -->