### PR TITLE
feat(template): support deploy by template code with -c/--code flag

### DIFF
--- a/internal/cmd/template/deploy/deploy.go
+++ b/internal/cmd/template/deploy/deploy.go
@@ -54,7 +54,7 @@ func NewCmdDeploy(f *cmdutil.Factory) *cobra.Command {
 func runDeploy(f *cmdutil.Factory, opts *Options) error {
 	var err error
 
-	if err := paramCheck(opts); err != nil {
+	if err := paramCheck(f, opts); err != nil {
 		return err
 	}
 
@@ -334,13 +334,42 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 	return nil
 }
 
-func paramCheck(opts *Options) error {
-	if opts.file == "" && opts.code == "" {
-		return fmt.Errorf("please specify template file by -f/--file or template code by -c/--code")
-	}
-
+func paramCheck(f *cmdutil.Factory, opts *Options) error {
 	if opts.file != "" && opts.code != "" {
 		return fmt.Errorf("please specify either -f/--file or -c/--code, not both")
+	}
+
+	if opts.file == "" && opts.code == "" {
+		if !f.Interactive {
+			return fmt.Errorf("please specify template file by -f/--file or template code by -c/--code")
+		}
+
+		sourceIdx, err := f.Prompter.Select("How would you like to specify the template?", "", []string{
+			"Template file (-f/--file)",
+			"Template code (-c/--code)",
+		})
+		if err != nil {
+			return fmt.Errorf("source selection failed: %w", err)
+		}
+
+		switch sourceIdx {
+		case 0:
+			input, err := f.Prompter.Input("Template file path: ", "")
+			if err != nil {
+				return fmt.Errorf("input failed: %w", err)
+			}
+			opts.file = input
+		case 1:
+			input, err := f.Prompter.Input("Template code: ", "")
+			if err != nil {
+				return fmt.Errorf("input failed: %w", err)
+			}
+			opts.code = input
+		}
+
+		if opts.file == "" && opts.code == "" {
+			return fmt.Errorf("no template source provided")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Add `-c/--code` flag to `template deploy` command
- Fetches template YAML from `https://zeabur.com/templates/<code>.yaml` and deploys it directly
- Mutually exclusive with `-f/--file` — only one can be specified

## Before

```bash
# Two-step process
zeabur template get -c KXL04P --raw > /tmp/mongodb.yaml
zeabur template deploy -f /tmp/mongodb.yaml --project-id <id>
```

## After

```bash
# One command
zeabur template deploy -c KXL04P --project-id <id>
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `template deploy --help` shows new `-c/--code` flag
- [ ] `template deploy -c KXL04P --project-id <id>` deploys MongoDB successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --code / -c option to deploy, letting you specify templates by code instead of a local file.
  * If a code is provided, the CLI fetches the template from a remote template URL with a 30s timeout and reports clear HTTP errors (including not found).
  * Improved parameter validation to require either a file or code and prevent providing both simultaneously; interactive prompts guide the choice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->