### PR TITLE
fix: variable update in non-interactive mode clears all existing variables

### DIFF
--- a/internal/cmd/variable/create/create.go
+++ b/internal/cmd/variable/create/create.go
@@ -69,9 +69,9 @@ func runCreateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 		if err != nil {
 			return err
 		}
-		keyValue := strings.Split(varInput, "=")
+		keyValue := strings.SplitN(varInput, "=", 2)
 		if len(keyValue) != 2 {
-			return fmt.Errorf("invalid input")
+			return fmt.Errorf("invalid input: expected KEY=VALUE format")
 		}
 		opts.keys[keyValue[0]] = keyValue[1]
 

--- a/internal/cmd/variable/update/update.go
+++ b/internal/cmd/variable/update/update.go
@@ -41,13 +41,11 @@ func NewCmdUpdateVariable(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runUpdateVariable(f *cmdutil.Factory, opts *Options) error {
-	opts.keys = make(map[string]string)
-
 	if f.Interactive {
+		opts.keys = make(map[string]string)
 		return runUpdateVariableInteractive(f, opts)
-	} else {
-		return runUpdateVariableNonInteractive(f, opts)
 	}
+	return runUpdateVariableNonInteractive(f, opts)
 }
 
 func runUpdateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
@@ -131,6 +129,23 @@ func runUpdateVariableNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		spinner.WithColor(cmdutil.SpinnerColor),
 		spinner.WithSuffix(fmt.Sprintf(" Updating variables of service: %s...", opts.name)),
 	)
+	s.Start()
+
+	// Fetch existing variables and merge with user-provided keys,
+	// so that unmentioned variables are preserved (not deleted).
+	// In interactive mode, opts.keys already contains the full
+	// variable map from the interactive flow.
+	varList, _, err := f.ApiClient.ListVariables(context.Background(), opts.id, opts.environmentID)
+	if err != nil {
+		s.Stop()
+		return err
+	}
+	mergedVars := varList.ToMap()
+	for k, v := range opts.keys {
+		mergedVars[k] = v
+	}
+	opts.keys = mergedVars
+
 	createVarResult, err := f.ApiClient.UpdateVariables(context.Background(), opts.id, opts.environmentID, opts.keys)
 	if err != nil {
 		s.Stop()

--- a/internal/cmd/variable/variable.go
+++ b/internal/cmd/variable/variable.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	variableCreateCmd "github.com/zeabur/cli/internal/cmd/variable/create"
-	varableDeleteCmd "github.com/zeabur/cli/internal/cmd/variable/delete"
+	variableDeleteCmd "github.com/zeabur/cli/internal/cmd/variable/delete"
 	variableEnvCmd "github.com/zeabur/cli/internal/cmd/variable/env"
 	variableListCmd "github.com/zeabur/cli/internal/cmd/variable/list"
 	variableUpdateCmd "github.com/zeabur/cli/internal/cmd/variable/update"
@@ -22,7 +22,7 @@ func NewCmdVariable(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(variableListCmd.NewCmdListVariables(f))
 	cmd.AddCommand(variableCreateCmd.NewCmdCreateVariable(f))
 	cmd.AddCommand(variableUpdateCmd.NewCmdUpdateVariable(f))
-	cmd.AddCommand(varableDeleteCmd.NewCmdDeleteVariable(f))
+	cmd.AddCommand(variableDeleteCmd.NewCmdDeleteVariable(f))
 	cmd.AddCommand(variableEnvCmd.NewCmdEnvVariable(f))
 
 	return cmd


### PR DESCRIPTION
## Summary

**`variable update -i=false -k "NEW=val"` silently deletes all existing variables.** This is a data-loss bug.

### Root cause

Two issues combine to cause this:

1. `runUpdateVariable()` (update.go:44) unconditionally resets `opts.keys` with `make(map[string]string)`, **wiping the CLI-parsed `--key` values** before they reach the handler
2. `runUpdateVariableNonInteractive()` passes this empty/partial map directly to `UpdateVariables()`, which is a **full-replace API** — unmentioned variables get deleted

Interactive mode is unaffected because `runUpdateVariableInteractive` fetches all existing variables and rebuilds the map before calling the non-interactive handler.

### Fix

Follow the same fetch-and-merge pattern already used by `variable create` ([create.go:115-127](internal/cmd/variable/create/create.go#L115-L127)) and `variable delete` ([delete.go:138-145](internal/cmd/variable/delete/delete.go#L138-L145)):

1. Move `make(map[string]string)` into the interactive branch only (don't wipe CLI args)
2. Fetch existing variables before calling `UpdateVariables`
3. Merge user-provided keys on top of existing ones
4. Start the spinner before the API call (was missing `s.Start()`)

### Additional fixes in this PR

- **`variable create` interactive**: `strings.Split(input, "=")` → `strings.SplitN(input, "=", 2)` — values containing `=` (e.g., `DATABASE_URL=postgres://host/db?sslmode=require`) were rejected as invalid input
- **Typo**: `varableDeleteCmd` → `variableDeleteCmd` in variable.go

## Test plan

- [ ] `zeabur variable update -i=false --id <svc> -k "NEW_VAR=hello"` should add `NEW_VAR` without affecting existing variables
- [ ] `zeabur variable update -i=false --id <svc> -k "EXISTING=new_value"` should update only that key
- [ ] Interactive `variable update` should still work as before
- [ ] `zeabur variable create` interactive with `DATABASE_URL=postgres://host?ssl=require` should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Variable creation now accepts values containing `=` characters.
  * Variable update now preserves existing variables and only modifies specified ones.
  * Improved error messaging for invalid variable input format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->