### PR TITLE
fix: prevent nil pointer panic in deploy when no projects exist

### DIFF
--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -126,6 +126,9 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 		if err != nil {
 			return err
 		}
+		if service == nil || environment == nil {
+			return nil
+		}
 		projectID = service.Project.ID
 	}
 


### PR DESCRIPTION
## Summary

First-time users with no projects hit a **nil pointer panic** when running `zeabur deploy`:

1. `selectInteractively` prompts "No projects found. Create one?"
2. User confirms → project is created → function returns `nil, nil, nil`
3. Caller dereferences `service.Project.ID` → **panic**

### Fix

Add nil check after `selectInteractively` returns. This matches the existing UX where the function already tells the user to "run this command again to deploy."

## Test plan
- [ ] Run `zeabur deploy` with no existing projects → should not panic
- [ ] Run `zeabur deploy` with existing projects → should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)