### PR TITLE
fix: close HTTP response bodies and fix 5xx status check logic

### DIFF
--- a/internal/cmd/template/create/create.go
+++ b/internal/cmd/template/create/create.go
@@ -57,6 +57,7 @@ func runCreate(f *cmdutil.Factory, opts Options) error {
 			f.Log.Errorf("fetch file failed: %v", err)
 			return err
 		}
+		defer get.Body.Close()
 
 		file, err = io.ReadAll(get.Body)
 		if err != nil {

--- a/internal/cmd/template/deploy/deploy.go
+++ b/internal/cmd/template/deploy/deploy.go
@@ -69,6 +69,7 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 			f.Log.Errorf("fetch file failed: %v", err)
 			return err
 		}
+		defer get.Body.Close()
 
 		file, err = io.ReadAll(get.Body)
 		if err != nil {
@@ -281,8 +282,9 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 			if err != nil {
 				continue
 			}
+			get.Body.Close()
 
-			if get.StatusCode%100 != 5 {
+			if get.StatusCode/100 != 5 {
 				s.Stop()
 				f.Log.Infof("Service ready, you can now visit via https://%s.zeabur.app/", d)
 				break

--- a/internal/cmd/template/update/update.go
+++ b/internal/cmd/template/update/update.go
@@ -62,6 +62,7 @@ func runUpdate(f *cmdutil.Factory, opts Options) error {
 			f.Log.Errorf("fetch file failed: %v", err)
 			return err
 		}
+		defer get.Body.Close()
 
 		file, err = io.ReadAll(get.Body)
 		if err != nil {


### PR DESCRIPTION
## Summary

**HTTP response body leak** in 3 template commands + health-check loop:
- `template deploy`, `template create`, `template update` all call `http.Get()` to fetch remote template files but never close the response body
- The health-check polling loop in `template deploy` also leaks on every iteration

**Incorrect 5xx detection** in template deploy health check:
- `get.StatusCode%100 != 5` checks if the last two digits equal 5 (e.g., 105, 205, 505), not whether it's a 5xx response
- For example, 502 % 100 = 2 (not 5), so it's treated as "ready" — works by accident for most cases but is semantically wrong
- Fix: `get.StatusCode/100 != 5` correctly checks the HTTP status class

### Files changed
- `internal/cmd/template/deploy/deploy.go` — body close + status fix
- `internal/cmd/template/create/create.go` — body close
- `internal/cmd/template/update/update.go` — body close

## Test plan
- [ ] `zeabur template deploy -f https://...` should not leak connections
- [ ] Health check should correctly detect 5xx vs non-5xx responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)