### PR TITLE
fix: correct restart/redeploy confirmation prompts and fix metric min/type

### DIFF
--- a/internal/cmd/service/metric/metric.go
+++ b/internal/cmd/service/metric/metric.go
@@ -108,7 +108,7 @@ func runMetricNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	upperCaseMetricType := strings.ToUpper(opts.metricType)
-	mt := model.MetricType(opts.metricType)
+	mt := model.MetricType(upperCaseMetricType)
 
 	startTime := time.Now().Add(-time.Duration(opts.hour) * time.Hour)
 	endTime := time.Now()
@@ -126,7 +126,8 @@ func runMetricNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		return nil
 	}
 
-	sum, avg, max, min := 0.0, 0.0, 0.0, 0.0
+	sum, avg, max := 0.0, 0.0, 0.0
+	min := metrics.Metrics[0].Value
 
 	for _, metric := range metrics.Metrics {
 		sum += metric.Value

--- a/internal/cmd/service/redeploy/redeploy.go
+++ b/internal/cmd/service/redeploy/redeploy.go
@@ -90,7 +90,7 @@ func runRedeployNonInteractive(f *cmdutil.Factory, opts *Options) error {
 
 	// double check
 	if f.Interactive && !opts.skipConfirm {
-		confirm, err := f.Prompter.Confirm(fmt.Sprintf("Are you sure to deploy service <%s>?", idOrName), true)
+		confirm, err := f.Prompter.Confirm(fmt.Sprintf("Are you sure to redeploy service <%s>?", idOrName), true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/service/restart/restart.go
+++ b/internal/cmd/service/restart/restart.go
@@ -90,7 +90,7 @@ func runRestartNonInteractive(f *cmdutil.Factory, opts *Options) error {
 
 	// double check
 	if f.Interactive && !opts.skipConfirm {
-		confirm, err := f.Prompter.Confirm(fmt.Sprintf("Are you sure to deploy service <%s>?", idOrName), true)
+		confirm, err := f.Prompter.Confirm(fmt.Sprintf("Are you sure to restart service <%s>?", idOrName), true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

**Confirmation prompt copy-paste errors:**
- `service restart` says "Are you sure to **deploy** service?" → should say "**restart**"
- `service redeploy` says "Are you sure to **deploy** service?" → should say "**redeploy**"

**Metric calculation bugs:**
- `min` initialized to `0.0` — positive metrics (CPU, memory, network) never go below 0, so `min` is always reported as `0.0`. Fix: initialize from first data point.
- `MetricType` constructed from original-case input (e.g., `"cpu"`) instead of uppercased `"CPU"`, causing `WithMeasureUnit()` switch statement to miss and display raw values without units.

### Files changed
- `internal/cmd/service/restart/restart.go` — prompt text
- `internal/cmd/service/redeploy/redeploy.go` — prompt text
- `internal/cmd/service/metric/metric.go` — min init + MetricType case

## Test plan
- [ ] `zeabur service restart` should show "Are you sure to restart..."
- [ ] `zeabur service redeploy` should show "Are you sure to redeploy..."
- [ ] `zeabur service metric --type cpu` should show correct min value and units

🤖 Generated with [Claude Code](https://claude.com/claude-code)