### PR TITLE
fix: use StringArrayVar for --key flag to preserve special characters

### DIFF
--- a/internal/cmd/variable/create/create.go
+++ b/internal/cmd/variable/create/create.go
@@ -17,6 +17,7 @@ type Options struct {
 	name          string
 	environmentID string
 	keys          map[string]string
+	rawKeys       []string
 	skipConfirm   bool
 	inputDone     bool
 }
@@ -36,7 +37,7 @@ func NewCmdCreateVariable(f *cmdutil.Factory) *cobra.Command {
 	util.AddServiceParam(cmd, &opts.id, &opts.name)
 	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, "Skip confirmation")
-	cmd.Flags().StringToStringVarP(&opts.keys, "key", "k", nil, "Key value pair of the variable")
+	cmd.Flags().StringArrayVarP(&opts.rawKeys, "key", "k", nil, "Key value pair of the variable (KEY=VALUE)")
 
 	return cmd
 }
@@ -85,7 +86,27 @@ func runCreateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 	return runCreateVariableNonInteractive(f, opts)
 }
 
+func parseRawKeys(rawKeys []string) (map[string]string, error) {
+	result := make(map[string]string, len(rawKeys))
+	for _, raw := range rawKeys {
+		parts := strings.SplitN(raw, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid --key format %q: expected KEY=VALUE", raw)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
 func runCreateVariableNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	// Parse rawKeys from StringArrayVar into the keys map (non-interactive mode)
+	if opts.keys == nil && len(opts.rawKeys) > 0 {
+		parsed, err := parseRawKeys(opts.rawKeys)
+		if err != nil {
+			return err
+		}
+		opts.keys = parsed
+	}
 	if opts.id == "" && opts.name != "" {
 		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
 		if err != nil {

--- a/internal/cmd/variable/update/update.go
+++ b/internal/cmd/variable/update/update.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
@@ -16,6 +17,7 @@ type Options struct {
 	name          string
 	environmentID string
 	keys          map[string]string
+	rawKeys       []string
 	skipConfirm   bool
 	inputDone     bool
 }
@@ -35,7 +37,7 @@ func NewCmdUpdateVariable(f *cmdutil.Factory) *cobra.Command {
 	util.AddServiceParam(cmd, &opts.id, &opts.name)
 	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, "Skip confirmation")
-	cmd.Flags().StringToStringVarP(&opts.keys, "key", "k", nil, "Key value pair of the variable")
+	cmd.Flags().StringArrayVarP(&opts.rawKeys, "key", "k", nil, "Key value pair of the variable (KEY=VALUE)")
 
 	return cmd
 }
@@ -104,7 +106,27 @@ func runUpdateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 	return runUpdateVariableNonInteractive(f, opts)
 }
 
+func parseRawKeys(rawKeys []string) (map[string]string, error) {
+	result := make(map[string]string, len(rawKeys))
+	for _, raw := range rawKeys {
+		parts := strings.SplitN(raw, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid --key format %q: expected KEY=VALUE", raw)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
 func runUpdateVariableNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	// Parse rawKeys from StringArrayVar into the keys map (non-interactive mode)
+	if opts.keys == nil && len(opts.rawKeys) > 0 {
+		parsed, err := parseRawKeys(opts.rawKeys)
+		if err != nil {
+			return err
+		}
+		opts.keys = parsed
+	}
 	if opts.id == "" && opts.name != "" {
 		service, err := util.GetServiceByName(f.Config, f.ApiClient, opts.name)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Switch `variable create` and `variable update` from `StringToStringVarP` to `StringArrayVarP`
- Manually split each `--key` entry on the **first** `=` only via `strings.SplitN(raw, "=", 2)`
- This preserves values containing `${}`, commas, and other special characters

## Problem
`--key 'DATABASE_URL=${POSTGRESQL.POSTGRES_CONNECTION_STRING}'` silently truncates or empties the value because Cobra's `StringToStringVar` uses an internal CSV parser that cannot handle these characters.

## Changes
- `internal/cmd/variable/create/create.go` — added `rawKeys []string` field, `parseRawKeys()` helper
- `internal/cmd/variable/update/update.go` — same changes

## Backward Compatibility
Users can still use `--key KEY=VALUE` format exactly as before. Values containing `=` signs (e.g., connection strings) are preserved because only the first `=` is used as the delimiter.

Fixes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Variable `create` and `update` commands now validate `--key/-k` input more strictly, rejecting empty keys and invalid KEY=VALUE formats with clear error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->