### PR TITLE
fix: reuse existing service by name instead of creating duplicates

### DIFF
--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -73,10 +73,27 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 				return err
 			}
 		} else {
-			// create a new service
-			service, err = f.ApiClient.CreateEmptyService(context.Background(), projectID, opts.name)
-			if err != nil {
-				return err
+			// check if a service with the same name already exists
+			if opts.name != "" {
+				existingServices, err := f.ApiClient.ListAllServices(context.Background(), projectID)
+				if err != nil {
+					return fmt.Errorf("listing services: %w", err)
+				}
+				for _, s := range existingServices {
+					if s.Name == opts.name {
+						service = s
+						f.Log.Infof("Found existing service '%s', redeploying...", opts.name)
+						break
+					}
+				}
+			}
+
+			// create a new service if no existing one was found
+			if service == nil {
+				service, err = f.ApiClient.CreateEmptyService(context.Background(), projectID, opts.name)
+				if err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Before creating a new service, check if one with the same `--name` already exists in the project
- If found, reuse its service ID and log: `Found existing service 'my-app', redeploying...`
- Only create a new service if no match is found

## Problem
When running `zeabur deploy --project-id <id> --name "my-app"` and a service named `my-app` already exists, the CLI creates a duplicate service named `my-app-over` instead of updating the existing one.

## Changes
- `internal/cmd/deploy/deploy.go` — added name-based lookup using `ListAllServices` before `CreateEmptyService`

## Before/After
```bash
# Before: creates "my-app-over" as a new service
zeabur deploy --project-id <id> --name "my-app" -i=false

# After: finds and reuses existing "my-app" service
zeabur deploy --project-id <id> --name "my-app" -i=false
# Output: Found existing service 'my-app', redeploying...
```

Fixes #203