### PR TITLE
fix: return error and stop spinner on domain delete failure

### DIFF
--- a/internal/cmd/domain/delete/delete.go
+++ b/internal/cmd/domain/delete/delete.go
@@ -69,6 +69,7 @@ func runDeleteDomainInteractive(f *cmdutil.Factory, opts *Options) error {
 	s.Start()
 	domainList, err := f.ApiClient.ListDomains(context.Background(), opts.id, opts.environmentID)
 	if err != nil {
+		s.Stop()
 		return err
 	}
 	s.Stop()
@@ -128,13 +129,13 @@ func runDeleteDomainNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	s.Start()
 	deleteResult, err := f.ApiClient.RemoveDomain(context.Background(), opts.domainName)
 	if err != nil {
+		s.Stop()
 		return err
 	}
 	s.Stop()
 
 	if !deleteResult {
-		f.Log.Warnf("Delete domain %s failed", opts.domainName)
-		return nil
+		return fmt.Errorf("delete domain %s failed", opts.domainName)
 	}
 
 	if f.JSON {


### PR DESCRIPTION
## Problem

`domain delete` has two related issues in `runDeleteDomainNonInteractive`:

**1. Spinner not stopped on API error**

Both `ListDomains` and `RemoveDomain` call `return err` before `s.Stop()`, leaving the spinner running after an error. This corrupts terminal output — the spinner animation continues rendering on top of the error message.

**2. Deletion failure returns `nil` (exit code 0)**

When `RemoveDomain` returns `false` (the API-level "failed" signal), the code logs a warning and returns `nil`:

```go
if !deleteResult {
    f.Log.Warnf("Delete domain %s failed", opts.domainName)
    return nil  // exit code 0
}
```

Callers (scripts, CI/CD pipelines) have no way to detect that the deletion did not actually succeed.

## Fix

- Call `s.Stop()` before each `return err` in the error paths
- Replace `f.Log.Warnf(...); return nil` with `return fmt.Errorf(...)` so failures propagate correctly

## Files changed

- `internal/cmd/domain/delete/delete.go` — 3-line change