### PR TITLE
fix: return error instead of nil when service delete is blocked in non-interactive mode

### DIFF
--- a/internal/cmd/service/delete/delete.go
+++ b/internal/cmd/service/delete/delete.go
@@ -85,8 +85,7 @@ func runDeleteNonInteractive(f *cmdutil.Factory, opts *Options) error {
 			return nil
 		}
 	} else if !f.Interactive && !opts.skipConfirm {
-		f.Log.Info("Please use --yes to confirm deletion without interactive prompt")
-		return nil
+		return fmt.Errorf("deletion requires --yes flag in non-interactive mode")
 	}
 
 	err := f.ApiClient.DeleteService(context.Background(), opts.id)


### PR DESCRIPTION
## Problem

`service delete` already has a guard for non-interactive mode without `--yes`:

```go
} else if !f.Interactive && !opts.skipConfirm {
    f.Log.Info("Please use --yes to confirm deletion without interactive prompt")
    return nil   // ← exit code 0
}
```

The guard is correct — deletion is blocked. But returning `nil` means exit code 0, so CI/CD scripts cannot tell whether the service was actually deleted or silently skipped.

## Fix

Replace `f.Log.Info(...); return nil` with `return fmt.Errorf(...)` so the exit code is non-zero when deletion is blocked.

The `--yes`/`-y` flag and all existing behavior are unchanged.

## Files changed

- `internal/cmd/service/delete/delete.go` — 1-line fix