### PR TITLE
fix: require --yes for money operations in non-interactive mode

### DIFF
--- a/internal/cmd/domain/purchase/purchase.go
+++ b/internal/cmd/domain/purchase/purchase.go
@@ -127,6 +127,8 @@ func runPurchaseNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		if !confirm {
 			return nil
 		}
+	} else if !f.Interactive && !opts.skipConfirm {
+		return fmt.Errorf("purchasing a domain requires --yes flag in non-interactive mode")
 	}
 
 	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,

--- a/internal/cmd/server/rent/rent.go
+++ b/internal/cmd/server/rent/rent.go
@@ -154,6 +154,8 @@ func runRentNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		if !confirm {
 			return nil
 		}
+	} else if !f.Interactive && !opts.skipConfirm {
+		return fmt.Errorf("renting a server requires --yes flag in non-interactive mode")
 	}
 
 	serverID, err := f.ApiClient.RentServer(context.Background(), opts.provider, opts.region, opts.plan)


### PR DESCRIPTION
## Summary

`server rent` and `domain purchase` skip confirmation entirely in non-interactive mode when `--yes` is not provided, allowing money operations to proceed silently. This can cause unintended charges in CI/CD pipelines.

### Bug

Both commands use `if f.Interactive && !opts.skipConfirm` to guard the confirmation prompt. In non-interactive mode this condition is false, so the code falls through to the API call without any confirmation or error.

**`server/rent/rent.go`:**
```go
if f.Interactive && !opts.skipConfirm {
    confirm, err := f.Prompter.Confirm(...)
    // ...
}
// NI mode: falls through directly to RentServer()
```

**`domain/purchase/purchase.go`:**
```go
if f.Interactive && !opts.skipConfirm {
    confirm, err := f.Prompter.Confirm(...)
    // ...
}
// NI mode: falls through directly to PurchaseDomain()
```

### Fix

Add an `else if` guard that returns an error when `--yes` is not provided in non-interactive mode:

```go
} else if !f.Interactive && !opts.skipConfirm {
    return fmt.Errorf("... requires --yes flag in non-interactive mode")
}
```

This is consistent with how `project delete` already handles the same scenario.

### Affected Commands
- `zeabur server rent` — rents a server (charges money)
- `zeabur domain purchase` — purchases a domain (charges money)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Domain purchases in non-interactive mode now require the `--yes` flag for confirmation
  * Server rentals in non-interactive mode now require the `--yes` flag for confirmation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->