### PR TITLE
fix: return error on domain create when domain is unavailable

### DIFF
--- a/internal/cmd/domain/create/create.go
+++ b/internal/cmd/domain/create/create.go
@@ -109,13 +109,13 @@ func runCreateDomainInteractive(f *cmdutil.Factory, opts *Options) error {
 	s.Start()
 	available, _, err := f.ApiClient.CheckDomainAvailable(context.Background(), opts.domainName, opts.IsGenerated, project.Region.ID)
 	if err != nil {
+		s.Stop()
 		return err
 	}
 	s.Stop()
 
 	if !available {
-		f.Log.Warnf("Domain %s is not available", opts.domainName)
-		return nil
+		return fmt.Errorf("domain %s is not available", opts.domainName)
 	}
 
 	s = spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,


### PR DESCRIPTION
## Summary

`domain create` logs a warning but returns `nil` (exit 0) when the domain is not available, causing CI/CD pipelines to think the domain was created successfully.

### Bug

```go
if !available {
    f.Log.Warnf("Domain %s is not available", opts.domainName)
    return nil  // exit 0 — CI/CD thinks domain was created
}
```

### Fix

- Return `fmt.Errorf(...)` instead of `nil` so the caller gets a non-zero exit code
- Add missing `s.Stop()` before early error return to prevent spinner from continuing after failure

```go
if !available {
    return fmt.Errorf("domain %s is not available", opts.domainName)
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced error handling during domain creation to properly handle failures when domain availability checks encounter issues
- Improved error messaging when requested domains are unavailable to provide users with explicit feedback instead of silent warnings
- Strengthened overall reliability of the domain creation workflow through better error management and user communication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->