### PR TITLE
fix: validate domain search query includes TLD

### DIFF
--- a/internal/cmd/domain/search/search.go
+++ b/internal/cmd/domain/search/search.go
@@ -44,7 +44,7 @@ func runSearch(f *cmdutil.Factory, opts *Options) error {
 		opts.query = query
 	}
 
-	if !strings.Contains(opts.query, ".") {
+	if !strings.ContainsRune(opts.query, '.') {
 		return fmt.Errorf("please provide a full domain name with TLD (e.g., example.com, example.io)")
 	}
 

--- a/internal/cmd/domain/search/search.go
+++ b/internal/cmd/domain/search/search.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
@@ -41,6 +42,10 @@ func runSearch(f *cmdutil.Factory, opts *Options) error {
 			return err
 		}
 		opts.query = query
+	}
+
+	if !strings.Contains(opts.query, ".") {
+		return fmt.Errorf("please provide a full domain name with TLD (e.g., example.com, example.io)")
 	}
 
 	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,


### PR DESCRIPTION
## Summary

- When searching without a TLD (e.g., `zeabur domain search antnest`), the command silently returns `{"available": false, "tld": ""}` which is misleading — users think the domain is taken when it was just an invalid query
- Add validation to require a dot in the domain name and show a helpful error message: `please provide a full domain name with TLD (e.g., example.com, example.io)`

## Reproduction

```bash
# Before fix: returns misleading "available: false"
$ zeabur domain search antnest --json
{"domain":"antnest","available":false,"price":null,"tld":""}

# After fix: clear error message
$ zeabur domain search antnest
Error: please provide a full domain name with TLD (e.g., example.com, example.io)

# Valid queries still work
$ zeabur domain search antnest-dessert.com --json
{"domain":"antnest-dessert.com","available":true,"price":1740,"tld":"com"}
```

## Test plan

- [x] `zeabur domain search antnest` → error with guidance
- [x] `zeabur domain search antnest-dessert.com` → works normally
- [x] `zeabur domain search google.com` → returns unavailable (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Domain search now requires a full domain name including a TLD (e.g., .com, .org, .net). Partial or missing-TLD queries will return a clear error prompting for a complete domain.
  * Existing availability checks and JSON/table outputs continue to work once a valid full domain is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->