### PR TITLE
fix(variable): use StringArrayVar to preserve special characters in --key values

### DIFF
--- a/internal/cmd/variable/create/create.go
+++ b/internal/cmd/variable/create/create.go
@@ -16,6 +16,7 @@ type Options struct {
 	id            string
 	name          string
 	environmentID string
+	rawKeys       []string
 	keys          map[string]string
 	skipConfirm   bool
 	inputDone     bool
@@ -36,17 +37,44 @@ func NewCmdCreateVariable(f *cmdutil.Factory) *cobra.Command {
 	util.AddServiceParam(cmd, &opts.id, &opts.name)
 	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, "Skip confirmation")
-	cmd.Flags().StringToStringVarP(&opts.keys, "key", "k", nil, "Key value pair of the variable")
+	cmd.Flags().StringArrayVarP(&opts.rawKeys, "key", "k", nil, "Key value pair of the variable (KEY=VALUE)")
 
 	return cmd
 }
 
 func runCreateVariable(f *cmdutil.Factory, opts *Options) error {
+	if err := parseRawKeys(opts); err != nil {
+		return err
+	}
+
 	if f.Interactive {
 		return runCreateVariableInteractive(f, opts)
 	} else {
 		return runCreateVariableNonInteractive(f, opts)
 	}
+}
+
+// parseRawKeys converts the raw "KEY=VALUE" strings from --key flags
+// into the keys map. It splits on the first "=" only, so values
+// containing "=", "${}", commas, and other special characters are preserved.
+func parseRawKeys(opts *Options) error {
+	if len(opts.rawKeys) == 0 {
+		return nil
+	}
+
+	if opts.keys == nil {
+		opts.keys = make(map[string]string, len(opts.rawKeys))
+	}
+
+	for _, kv := range opts.rawKeys {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return fmt.Errorf("invalid key-value pair %q: expected KEY=VALUE format", kv)
+		}
+		opts.keys[parts[0]] = parts[1]
+	}
+
+	return nil
 }
 
 func runCreateVariableInteractive(f *cmdutil.Factory, opts *Options) error {

--- a/internal/cmd/variable/update/update.go
+++ b/internal/cmd/variable/update/update.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ type Options struct {
 	id            string
 	name          string
 	environmentID string
+	rawKeys       []string
 	keys          map[string]string
 	skipConfirm   bool
 	inputDone     bool
@@ -35,17 +37,44 @@ func NewCmdUpdateVariable(f *cmdutil.Factory) *cobra.Command {
 	util.AddServiceParam(cmd, &opts.id, &opts.name)
 	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, "Skip confirmation")
-	cmd.Flags().StringToStringVarP(&opts.keys, "key", "k", nil, "Key value pair of the variable")
+	cmd.Flags().StringArrayVarP(&opts.rawKeys, "key", "k", nil, "Key value pair of the variable (KEY=VALUE)")
 
 	return cmd
 }
 
 func runUpdateVariable(f *cmdutil.Factory, opts *Options) error {
+	if err := parseRawKeys(opts); err != nil {
+		return err
+	}
+
 	if f.Interactive {
 		opts.keys = make(map[string]string)
 		return runUpdateVariableInteractive(f, opts)
 	}
 	return runUpdateVariableNonInteractive(f, opts)
+}
+
+// parseRawKeys converts the raw "KEY=VALUE" strings from --key flags
+// into the keys map. It splits on the first "=" only, so values
+// containing "=", "${}", commas, and other special characters are preserved.
+func parseRawKeys(opts *Options) error {
+	if len(opts.rawKeys) == 0 {
+		return nil
+	}
+
+	if opts.keys == nil {
+		opts.keys = make(map[string]string, len(opts.rawKeys))
+	}
+
+	for _, kv := range opts.rawKeys {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return fmt.Errorf("invalid key-value pair %q: expected KEY=VALUE format", kv)
+		}
+		opts.keys[parts[0]] = parts[1]
+	}
+
+	return nil
 }
 
 func runUpdateVariableInteractive(f *cmdutil.Factory, opts *Options) error {


### PR DESCRIPTION
## Summary

- Fixes `variable create` and `variable update` `--key` flag silently truncating or emptying values that contain `${}`, commas, or other special characters
- Switches from Cobra's `StringToStringVarP` (which uses an internal CSV parser) to `StringArrayVarP` with manual `SplitN` on the first `=`
- Values like `DATABASE_URL=${POSTGRESQL.POSTGRES_CONNECTION_STRING}` now work correctly

## Root Cause

`StringToStringVarP` internally uses Go's `encoding/csv` reader to parse `KEY=VALUE` pairs. This parser treats `${}`, commas, and quotes as special characters, causing values to be silently truncated or emptied.

## Changes

| File | Change |
|------|--------|
| `internal/cmd/variable/create/create.go` | Replace `StringToStringVarP` with `StringArrayVarP` + `parseRawKeys()` |
| `internal/cmd/variable/update/update.go` | Same fix applied |

## Usage (unchanged)

```bash
# Before: value gets truncated to ""
zeabur variable create --id <id> -k 'DATABASE_URL=${POSTGRESQL.POSTGRES_CONNECTION_STRING}' -i=false

# After: value preserved correctly
zeabur variable create --id <id> -k 'DATABASE_URL=${POSTGRESQL.POSTGRES_CONNECTION_STRING}' -i=false

# Multiple variables (now use separate -k flags instead of comma-separated)
zeabur variable create --id <id> -k 'KEY1=value1' -k 'KEY2=value,with,commas' -i=false
```

## Test plan

- [ ] Verify `variable create -k 'KEY=${REF}'` preserves `${REF}` in the value
- [ ] Verify `variable create -k 'KEY=val,with,commas'` preserves commas
- [ ] Verify `variable update -k 'KEY=new_value'` works correctly
- [ ] Verify multiple `-k` flags work: `-k 'A=1' -k 'B=2'`
- [ ] Verify interactive mode still works as before

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `--key/-k` flag in variable create and update commands to accept repeatable `KEY=VALUE` format.
  * Improved handling of special characters (including `=`) within variable values.

* **Bug Fixes**
  * Added validation to reject malformed key inputs and provide clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->