### PR TITLE
fix(domain): add --domain validation and fix spinner leaks in domain create

### DIFF
--- a/internal/cmd/domain/create/create.go
+++ b/internal/cmd/domain/create/create.go
@@ -109,6 +109,7 @@ func runCreateDomainInteractive(f *cmdutil.Factory, opts *Options) error {
 	s.Start()
 	available, _, err := f.ApiClient.CheckDomainAvailable(context.Background(), opts.domainName, opts.IsGenerated, project.Region.ID)
 	if err != nil {
+		s.Stop()
 		return err
 	}
 	s.Stop()
@@ -125,6 +126,7 @@ func runCreateDomainInteractive(f *cmdutil.Factory, opts *Options) error {
 	s.Start()
 	existedDomains, err := f.ApiClient.ListDomains(context.Background(), opts.id, opts.environmentID)
 	if err != nil {
+		s.Stop()
 		return err
 	}
 	s.Stop()
@@ -162,6 +164,10 @@ func runCreateDomainNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		return fmt.Errorf("--id or --name is required")
 	}
 
+	if opts.domainName == "" {
+		return fmt.Errorf("--domain is required in non-interactive mode")
+	}
+
 	if opts.environmentID == "" {
 		envID, err := util.ResolveEnvironmentIDByServiceID(f.ApiClient, opts.id)
 		if err != nil {
@@ -184,6 +190,7 @@ func runCreateDomainNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	if err != nil {
+		s.Stop()
 		return fmt.Errorf("add domain failed: %w", err)
 	}
 	s.Stop()

--- a/internal/cmd/domain/create/create.go
+++ b/internal/cmd/domain/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
@@ -164,7 +165,7 @@ func runCreateDomainNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		return fmt.Errorf("--id or --name is required")
 	}
 
-	if opts.domainName == "" {
+	if strings.TrimSpace(opts.domainName) == "" {
 		return fmt.Errorf("--domain is required in non-interactive mode")
 	}
 


### PR DESCRIPTION
## Summary

- Add missing `--domain` flag validation in non-interactive mode — previously, omitting `--domain` would pass an empty string to the API, producing a confusing server error
- Fix spinner goroutine leaks in 3 error paths where `s.Stop()` was not called before returning

## Changes

| Location | Fix |
|----------|-----|
| `runCreateDomainNonInteractive` | Add `--domain` empty check with clear error message |
| `runCreateDomainNonInteractive` line 192 | Call `s.Stop()` before returning on `AddDomain` error |
| `runCreateDomainInteractive` line 111 | Call `s.Stop()` before returning on `CheckDomainAvailable` error |
| `runCreateDomainInteractive` line 128 | Call `s.Stop()` before returning on `ListDomains` error |

## Reproducing the bug

```bash
# Missing --domain: previously sent empty string to API
zeabur domain create --id <service-id> -g -i=false
# Before: confusing API error
# After: "Error: --domain is required in non-interactive mode"
```

## Test plan

- [ ] Verify `domain create --id <id> -i=false` without `--domain` returns clear error
- [ ] Verify `domain create --id <id> --domain test -g -i=false` still works
- [ ] Verify spinner does not leak on API errors (no lingering animation in terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented command hangs by ensuring progress indicators are properly stopped on error paths during domain creation.
  * Added validation for domain name in non-interactive mode, rejecting empty or whitespace-only values.
  * Improved error handling consistency so failures during domain operations fail cleanly without leaving incomplete state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->