### PR TITLE
fix(deploy): reuse existing service by name to prevent duplicates

### DIFF
--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -72,8 +72,26 @@ func runDeploy(f *cmdutil.Factory, opts *Options) error {
 			if err != nil {
 				return err
 			}
+		} else if !opts.create {
+			// Look up existing service by name to avoid creating duplicates
+			existingServices, err := f.ApiClient.ListAllServices(context.Background(), projectID)
+			if err != nil {
+				return fmt.Errorf("listing existing services: %w", err)
+			}
+			for _, s := range existingServices {
+				if s.Name == opts.name {
+					service = s
+					break
+				}
+			}
+			if service == nil {
+				service, err = f.ApiClient.CreateEmptyService(context.Background(), projectID, opts.name)
+				if err != nil {
+					return err
+				}
+			}
 		} else {
-			// create a new service
+			// --create flag: always create a new service
 			service, err = f.ApiClient.CreateEmptyService(context.Background(), projectID, opts.name)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

- When deploying with `--project-id` and `--name` but without `--service-id`, the CLI now checks if a service with the same name already exists before creating a new one
- If found, it reuses the existing service (same as providing `--service-id`)
- The `--create` flag can still be used to explicitly force creating a new service

## Root Cause

In `runDeploy`, when `--project-id` is provided without `--service-id`, the code calls `CreateEmptyService()` unconditionally without checking for name collisions. This creates duplicate services (e.g. `my-app-over`).

## Changes

- `internal/cmd/deploy/deploy.go`: Before creating a new service, call `ListAllServices` to check if one with the same name already exists. If it does, reuse it. If `--create` is explicitly set, always create a new service.

Fixes #203

## Test plan
- [ ] Deploy with `--project-id --name "my-app"` twice — second deploy should update existing service, not create duplicate
- [ ] Deploy with `--project-id --name "my-app" --create` — should always create a new service
- [ ] Deploy with `--project-id --service-id` — behavior unchanged (uses provided service ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)