### PR TITLE
fix(log): auto-resolve deploymentID for runtime logs

### DIFF
--- a/internal/cmd/deployment/log/log.go
+++ b/internal/cmd/deployment/log/log.go
@@ -119,24 +119,25 @@ func queryLogs(f *cmdutil.Factory, opts *Options) error {
 	var logs model.Logs
 	var err error
 
+	// Auto-resolve deploymentID if not provided
+	deploymentID := opts.deploymentID
+	if deploymentID == "" {
+		deployment, exist, e := f.ApiClient.GetLatestDeployment(context.Background(), opts.serviceID, opts.environmentID)
+		if e == nil && exist {
+			deploymentID = deployment.ID
+			f.Log.Infof("Deployment ID: %s", deploymentID)
+		}
+	}
+
 	switch opts.logType {
 	case logTypeRuntime:
-		logs, err = f.ApiClient.GetRuntimeLogs(context.Background(), opts.serviceID, opts.environmentID, opts.deploymentID)
+		logs, err = f.ApiClient.GetRuntimeLogs(context.Background(), opts.serviceID, opts.environmentID, deploymentID)
 		if err != nil {
 			return fmt.Errorf("failed to get runtime logs: %w", err)
 		}
 	case logTypeBuild:
-		deploymentID := opts.deploymentID
 		if deploymentID == "" {
-			deployment, exist, e := f.ApiClient.GetLatestDeployment(context.Background(), opts.serviceID, opts.environmentID)
-			if e != nil {
-				return fmt.Errorf("failed to get latest deployment: %w", e)
-			}
-			if !exist {
-				return fmt.Errorf("no deployment found for service %s and environment %s", opts.serviceID, opts.environmentID)
-			}
-			deploymentID = deployment.ID
-			f.Log.Infof("Deployment ID: %s", deploymentID)
+			return fmt.Errorf("no deployment found for service %s and environment %s", opts.serviceID, opts.environmentID)
 		}
 		logs, err = f.ApiClient.GetBuildLogs(context.Background(), deploymentID)
 		if err != nil {

--- a/internal/cmd/deployment/log/log.go
+++ b/internal/cmd/deployment/log/log.go
@@ -123,7 +123,10 @@ func queryLogs(f *cmdutil.Factory, opts *Options) error {
 	deploymentID := opts.deploymentID
 	if deploymentID == "" {
 		deployment, exist, e := f.ApiClient.GetLatestDeployment(context.Background(), opts.serviceID, opts.environmentID)
-		if e == nil && exist {
+		if e != nil {
+			return fmt.Errorf("failed to get latest deployment: %w", e)
+		}
+		if exist {
 			deploymentID = deployment.ID
 			f.Log.Infof("Deployment ID: %s", deploymentID)
 		}

--- a/internal/cmd/deployment/log/log.go
+++ b/internal/cmd/deployment/log/log.go
@@ -140,7 +140,7 @@ func queryLogs(f *cmdutil.Factory, opts *Options) error {
 		}
 	case logTypeBuild:
 		if deploymentID == "" {
-			return fmt.Errorf("no deployment found for service %s and environment %s", opts.serviceID, opts.environmentID)
+			return fmt.Errorf("no build logs available: this service was started from a container image and was not built on Zeabur")
 		}
 		logs, err = f.ApiClient.GetBuildLogs(context.Background(), deploymentID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Runtime logs on dedicated servers require a `deploymentID` to query ClickHouse, but the CLI only auto-resolved it for build logs, not runtime logs
- When users omitted `--deployment-id`, runtime log queries returned empty results
- Now the CLI attempts to resolve the latest deployment before querying; if no deployment exists (pure image services), it falls back to the original prebuilt query path

## Test plan
- [x] `zeabur deployment log --service-id <git/upload service> -t runtime` — auto-resolves deploymentID, returns logs
- [x] `zeabur deployment log --service-id <pure image service> -t runtime` — no deployment, falls back to prebuilt path, returns logs
- [x] `zeabur deployment log --service-id <service> -t build` — still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment log retrieval now automatically resolves the correct deployment identifier when not provided, unifying runtime and build log behavior.
  * Build log requests now return a clearer error when no build logs exist: "no build logs available: this service was started from a container image and was not built on Zeabur".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->