### PR TITLE
feat(network): improve service network output clarity

### DIFF
--- a/internal/cmd/service/network/network.go
+++ b/internal/cmd/service/network/network.go
@@ -91,6 +91,12 @@ func runNetwork(f *cmdutil.Factory, opts *Options) error {
 	var portForwardedHost string
 
 	if opts.environmentID != "" {
+		ports, err = f.ApiClient.GetServicePorts(ctx, opts.id, opts.environmentID)
+		if err != nil {
+			s.Stop()
+			return err
+		}
+
 		portForwardingMode, err = f.ApiClient.GetPortForwardingMode(ctx, opts.id, opts.environmentID)
 		if err != nil {
 			s.Stop()
@@ -98,12 +104,6 @@ func runNetwork(f *cmdutil.Factory, opts *Options) error {
 		}
 
 		if portForwardingMode == model.PortForwardingModeEnabled {
-			ports, err = f.ApiClient.GetServicePorts(ctx, opts.id, opts.environmentID)
-			if err != nil {
-				s.Stop()
-				return err
-			}
-
 			portForwardedHost, err = f.ApiClient.GetPortForwardedHost(ctx, opts.id)
 			if err != nil {
 				s.Stop()
@@ -119,36 +119,45 @@ func runNetwork(f *cmdutil.Factory, opts *Options) error {
 			"dnsName": dnsName + ".zeabur.internal",
 		}
 		if opts.environmentID != "" {
+			portList := make([]map[string]interface{}, 0, len(ports))
+			for _, p := range ports {
+				pm := map[string]interface{}{
+					"id":   p.ID,
+					"port": p.Port,
+					"type": p.Type,
+				}
+				if p.ForwardedPort != nil {
+					pm["forwardedPort"] = *p.ForwardedPort
+				}
+				portList = append(portList, pm)
+			}
+			result["ports"] = portList
 			result["portForwardingMode"] = string(portForwardingMode)
 			if portForwardingMode == model.PortForwardingModeEnabled {
 				result["portForwardedHost"] = portForwardedHost
-				portList := make([]map[string]interface{}, 0, len(ports))
-				for _, p := range ports {
-					pm := map[string]interface{}{
-						"id":   p.ID,
-						"port": p.Port,
-						"type": p.Type,
-					}
-					if p.ForwardedPort != nil {
-						pm["forwardedPort"] = *p.ForwardedPort
-					}
-					portList = append(portList, pm)
-				}
-				result["ports"] = portList
 			}
 		}
 		return f.Printer.JSON(result)
 	}
 
-	f.Log.Infof("Private DNS name for %s: %s", opts.name, dnsName+".zeabur.internal")
+	internalHost := dnsName + ".zeabur.internal"
 
+	f.Log.Infof("Private Networking (between services on Zeabur)")
+	for _, p := range ports {
+		f.Log.Infof("  %s (%s): %s:%d", p.ID, p.Type, internalHost, p.Port)
+	}
+
+	fmt.Println()
+	f.Log.Infof("Public Networking (connect from outside Zeabur)")
 	if opts.environmentID != "" {
-		f.Log.Infof("Port forwarding: %s", portForwardingMode)
-		if portForwardingMode == model.PortForwardingModeEnabled && portForwardedHost != "" {
-			for _, p := range ports {
-				if p.ForwardedPort != nil && (p.Type == "TCP" || p.Type == "UDP") {
-					f.Log.Infof("  %s (%s %d) → %s:%d", p.ID, p.Type, p.Port, portForwardedHost, *p.ForwardedPort)
-				}
+		for _, p := range ports {
+			if p.Type == "HTTP" {
+				f.Log.Infof("  %s (%s): bind a domain to access externally", p.ID, p.Type)
+			} else if portForwardingMode == model.PortForwardingModeEnabled && portForwardedHost != "" && p.ForwardedPort != nil {
+				f.Log.Infof("  %s (%s): %s:%d", p.ID, p.Type, portForwardedHost, *p.ForwardedPort)
+			} else {
+				f.Log.Warnf("  %s (%s): port forwarding is disabled", p.ID, p.Type)
+				f.Log.Infof("    To enable, run: npx zeabur@latest service port-forward --id %s --enable", opts.id)
 			}
 		}
 	}

--- a/internal/cmd/service/network/network.go
+++ b/internal/cmd/service/network/network.go
@@ -142,6 +142,16 @@ func runNetwork(f *cmdutil.Factory, opts *Options) error {
 
 	internalHost := dnsName + ".zeabur.internal"
 
+	if len(ports) == 0 {
+		f.Log.Infof("Private DNS name: %s", internalHost)
+		if opts.environmentID == "" {
+			f.Log.Warnf("No environment specified; port details unavailable")
+		} else {
+			f.Log.Warnf("No ports configured for this service")
+		}
+		return nil
+	}
+
 	f.Log.Infof("Private Networking (between services on Zeabur)")
 	for _, p := range ports {
 		f.Log.Infof("  %s (%s): %s:%d", p.ID, p.Type, internalHost, p.Port)


### PR DESCRIPTION
## Summary
- Restructure `service network` output into **Private Networking** and **Public Networking** sections
- Each port shows its type (TCP/HTTP/UDP) and access method:
  - TCP/UDP: forwarded host:port, or prompt to enable port forwarding
  - HTTP: indicates domain binding is needed
- Always fetch ports (not only when port forwarding is enabled) so private networking info is always shown
- JSON output also always includes ports array

### Before
```
INFO  Private DNS name for : mysql.zeabur.internal
INFO  Port forwarding: ENABLED
INFO    database (TCP 3306) → 35.243.251.153:31476
```

### After
```
INFO  Private Networking (between services on Zeabur)
INFO    database (TCP): mysql.zeabur.internal:3306

INFO  Public Networking (connect from outside Zeabur)
INFO    database (TCP): 35.243.251.153:31476
```

## Test plan
- [ ] `service network` with TCP service (port forwarding enabled) — shows forwarded host:port
- [ ] `service network` with TCP service (port forwarding disabled) — shows warning + enable command
- [ ] `service network` with HTTP service — shows "bind a domain to access externally"
- [ ] `service network --json` — ports array always present regardless of port forwarding state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant port retrieval and ensured port information is consistently included when an environment is specified.
  * Added early handling and clear warnings when no service ports are found.

* **Improvements**
  * Reorganized output to separate Private and Public networking sections.
  * Shows all service ports with type, internal host and port.
  * Improved port forwarding messages: HTTP access lines, forwarded addresses when available, and clear enable-forwarding guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->