### PR TITLE
fix(variable/update): stop exposing secret values in output

### DIFF
--- a/internal/cmd/variable/update/update.go
+++ b/internal/cmd/variable/update/update.go
@@ -16,8 +16,18 @@ type Options struct {
 	name          string
 	environmentID string
 	keys          map[string]string
+	updatedKeys   []string // tracks only the keys the user explicitly changed
 	skipConfirm   bool
 	inputDone     bool
+}
+
+// maskValue masks a variable value for display, showing only the first 3
+// characters followed by asterisks. Short values are fully masked.
+func maskValue(v string) string {
+	if len(v) <= 3 {
+		return "***"
+	}
+	return v[:3] + "***"
 }
 
 func NewCmdUpdateVariable(f *cmdutil.Factory) *cobra.Command {
@@ -76,7 +86,7 @@ func runUpdateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 	selectTable := make([]string, 0, len(varMap))
 	for k, v := range varMap {
 		keyTable = append(keyTable, k)
-		selectTable = append(selectTable, fmt.Sprintf("%s = %s", k, v))
+		selectTable = append(selectTable, fmt.Sprintf("%s = %s", k, maskValue(v)))
 		opts.keys[k] = v
 	}
 
@@ -93,6 +103,7 @@ func runUpdateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 			return err
 		}
 		opts.keys[keyTable[updateVarSelect]] = varInput
+		opts.updatedKeys = append(opts.updatedKeys, keyTable[updateVarSelect])
 
 		doneConfirm, err := f.Prompter.Confirm("Are you done entering value of variable?", false)
 		if err != nil {
@@ -123,6 +134,15 @@ func runUpdateVariableNonInteractive(f *cmdutil.Factory, opts *Options) error {
 			return err
 		}
 		opts.environmentID = envID
+	}
+
+	// Remember which keys the user explicitly requested to update,
+	// so we only show those in the output (not the full merged set).
+	// In interactive mode, updatedKeys is already populated.
+	if len(opts.updatedKeys) == 0 {
+		for k := range opts.keys {
+			opts.updatedKeys = append(opts.updatedKeys, k)
+		}
 	}
 
 	s := spinner.New(cmdutil.SpinnerCharSet, cmdutil.SpinnerInterval,
@@ -158,20 +178,20 @@ func runUpdateVariableNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	s.Stop()
 
 	if f.JSON {
-		out := make([]map[string]string, 0, len(opts.keys))
-		for k, v := range opts.keys {
-			out = append(out, map[string]string{"Key": k, "Value": v})
+		out := make([]map[string]string, 0, len(opts.updatedKeys))
+		for _, k := range opts.updatedKeys {
+			out = append(out, map[string]string{"Key": k})
 		}
 		return f.Printer.JSON(out)
 	}
 
 	f.Log.Infof("Successfully updated variables of service: %s\n", opts.name)
 
-	table := make([][]string, 0, len(opts.keys))
-	for k, v := range opts.keys {
-		table = append(table, []string{k, v})
+	table := make([][]string, 0, len(opts.updatedKeys))
+	for _, k := range opts.updatedKeys {
+		table = append(table, []string{k})
 	}
-	f.Printer.Table([]string{"Key", "Value"}, table)
+	f.Printer.Table([]string{"Key"}, table)
 
 	return nil
 }

--- a/internal/cmd/variable/update/update.go
+++ b/internal/cmd/variable/update/update.go
@@ -102,8 +102,19 @@ func runUpdateVariableInteractive(f *cmdutil.Factory, opts *Options) error {
 		if err != nil {
 			return err
 		}
-		opts.keys[keyTable[updateVarSelect]] = varInput
-		opts.updatedKeys = append(opts.updatedKeys, keyTable[updateVarSelect])
+		selectedKey := keyTable[updateVarSelect]
+		opts.keys[selectedKey] = varInput
+
+		seen := false
+		for _, k := range opts.updatedKeys {
+			if k == selectedKey {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			opts.updatedKeys = append(opts.updatedKeys, selectedKey)
+		}
 
 		doneConfirm, err := f.Prompter.Confirm("Are you done entering value of variable?", false)
 		if err != nil {


### PR DESCRIPTION
## Summary
- **`variable update` no longer prints secret values** in table or JSON output — only the key names of explicitly updated variables are shown
- **Interactive mode masks existing values** in the selection prompt (e.g., `PASSWORD = K6H***` instead of the full value)
- Fixes the issue where merging with existing variables caused ALL key-value pairs to be dumped, including secrets the user didn't touch

Closes SEI-413

## Test plan
- [ ] Run `zeabur variable update --id <id> -i=false -k "FOO=bar"` — output should show only `FOO`, no value
- [ ] Run with `--json` — output should be `[{"Key": "FOO"}]`, no `Value` field
- [ ] Run in interactive mode — selection prompt should show masked values
- [ ] Verify other existing variables (e.g., `PASSWORD`) are not leaked in any output mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Features**
  * Variable values are now masked during interactive variable selection.

* **Changes**
  * Interactive mode now records which keys you explicitly modify so only those are reported.
  * Non-interactive mode similarly reports only explicitly modified keys when applicable.
  * JSON and table outputs now list only the modified keys (no values displayed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->