### PR TITLE
feat: add `zeabur file list/read` commands

### DIFF
--- a/internal/cmd/file/file.go
+++ b/internal/cmd/file/file.go
@@ -1,0 +1,21 @@
+package file
+
+import (
+	"github.com/spf13/cobra"
+
+	fileListCmd "github.com/zeabur/cli/internal/cmd/file/list"
+	fileReadCmd "github.com/zeabur/cli/internal/cmd/file/read"
+	"github.com/zeabur/cli/internal/cmdutil"
+)
+
+func NewCmdFile(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "file <command>",
+		Short: "Manage uploaded files",
+	}
+
+	cmd.AddCommand(fileListCmd.NewCmdList(f))
+	cmd.AddCommand(fileReadCmd.NewCmdRead(f))
+
+	return cmd
+}

--- a/internal/cmd/file/list/list.go
+++ b/internal/cmd/file/list/list.go
@@ -1,0 +1,63 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+)
+
+type Options struct {
+	uploadID string
+	path     string
+}
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:     "list <upload-id> [path]",
+		Short:   "List files in an upload",
+		Aliases: []string{"ls"},
+		Args:    cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.uploadID = args[0]
+			if len(args) > 1 {
+				opts.path = args[1]
+			}
+			return runList(f, opts)
+		},
+	}
+
+	return cmd
+}
+
+func runList(f *cmdutil.Factory, opts *Options) error {
+	var pathPtr *string
+	if opts.path != "" {
+		pathPtr = &opts.path
+	}
+
+	files, err := f.ApiClient.ListUploadFiles(context.Background(), opts.uploadID, pathPtr)
+	if err != nil {
+		return fmt.Errorf("list files failed: %w", err)
+	}
+
+	if len(files) == 0 {
+		if f.JSON {
+			return f.Printer.JSON([]any{})
+		}
+		f.Log.Infof("No files found")
+		return nil
+	}
+
+	if f.JSON {
+		return f.Printer.JSON(files)
+	}
+
+	fmt.Println(strings.Join(files, "\n"))
+
+	return nil
+}

--- a/internal/cmd/file/read/read.go
+++ b/internal/cmd/file/read/read.go
@@ -1,0 +1,49 @@
+package read
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+)
+
+type Options struct {
+	uploadID string
+	path     string
+}
+
+func NewCmdRead(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "read <upload-id> <path>",
+		Short: "Read a file from an upload",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.uploadID = args[0]
+			opts.path = args[1]
+			return runRead(f, opts)
+		},
+	}
+
+	return cmd
+}
+
+func runRead(f *cmdutil.Factory, opts *Options) error {
+	content, err := f.ApiClient.ReadUploadFile(context.Background(), opts.uploadID, opts.path)
+	if err != nil {
+		return fmt.Errorf("read file failed: %w", err)
+	}
+
+	if f.JSON {
+		return f.Printer.JSON(map[string]string{
+			"path":    opts.path,
+			"content": content,
+		})
+	}
+
+	fmt.Print(content)
+
+	return nil
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -20,6 +20,7 @@ import (
 	deploymentCmd "github.com/zeabur/cli/internal/cmd/deployment"
 	domainCmd "github.com/zeabur/cli/internal/cmd/domain"
 	emailCmd "github.com/zeabur/cli/internal/cmd/email"
+	fileCmd "github.com/zeabur/cli/internal/cmd/file"
 	profileCmd "github.com/zeabur/cli/internal/cmd/profile"
 	projectCmd "github.com/zeabur/cli/internal/cmd/project"
 	serverCmd "github.com/zeabur/cli/internal/cmd/server"
@@ -161,6 +162,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, commit, date string) (*cobra.Comman
 	cmd.AddCommand(completionCmd.NewCmdCompletion(f))
 	cmd.AddCommand(variableCmd.NewCmdVariable(f))
 	cmd.AddCommand(emailCmd.NewCmdEmail(f))
+	cmd.AddCommand(fileCmd.NewCmdFile(f))
 	cmd.AddCommand(aihubCmd.NewCmdAIHub(f))
 
 	// replace default help command with our custom one that supports --all

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+)
+
+func (c *client) ListUploadFiles(ctx context.Context, uploadID string, path *string) ([]string, error) {
+	var query struct {
+		Files []string `graphql:"files(uploadID: $uploadID, path: $path)"`
+	}
+
+	err := c.Query(ctx, &query, V{
+		"uploadID": ObjectID(uploadID),
+		"path":     path,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return query.Files, nil
+}
+
+func (c *client) ReadUploadFile(ctx context.Context, uploadID string, path string) (string, error) {
+	var query struct {
+		FileContent string `graphql:"fileContent(uploadID: $uploadID, path: $path)"`
+	}
+
+	err := c.Query(ctx, &query, V{
+		"uploadID": ObjectID(uploadID),
+		"path":     path,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return query.FileContent, nil
+}

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -23,6 +23,7 @@ type Client interface {
 	AIHubAPI
 	ZSendAPI
 	RegisteredDomainAPI
+	FileAPI
 }
 
 type (
@@ -176,6 +177,11 @@ type (
 
 		ResendRegistrantVerificationEmail(ctx context.Context, registeredDomainID string) error
 		UpdateRegistrantContact(ctx context.Context, registeredDomainID string, input model.UpdateRegistrantContactInput) error
+	}
+
+	FileAPI interface {
+		ListUploadFiles(ctx context.Context, uploadID string, path *string) ([]string, error)
+		ReadUploadFile(ctx context.Context, uploadID string, path string) (string, error)
 	}
 
 	ZSendAPI interface {


### PR DESCRIPTION
## Summary
- Add `zeabur file list <upload_id> [path]` to list files in an upload
- Add `zeabur file read <upload_id> <path>` to read file content
- New `FileAPI` interface in `pkg/api/` with GraphQL queries (`files()` / `fileContent()`)

This enables the skilled agent to access user-uploaded project files via CLI (bash + skill), instead of requiring SDK tools.

## Test plan
- [x] `zeabur file list <upload_id>` — lists root directory
- [x] `zeabur file list <upload_id> src/` — lists subdirectory
- [x] `zeabur file read <upload_id> package.json` — reads file content
- [x] `--json` flag outputs JSON format
- [x] Tested with real upload IDs against production API

Closes DES-536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `file` command for managing uploaded files
* Added `file list` subcommand to view files in an upload with optional path filtering
* Added `file read` subcommand to read file contents from an upload
* Both commands support JSON output format for programmatic use

<!-- end of auto-generated comment: release notes by coderabbit.ai -->