### PR TITLE
feat: add `zeabur service search-repo` command

### DIFF
--- a/internal/cmd/service/search-repo/search_repo.go
+++ b/internal/cmd/service/search-repo/search_repo.go
@@ -1,0 +1,62 @@
+package searchrepo
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+)
+
+// NewCmdSearchRepo creates the service search-repo command.
+func NewCmdSearchRepo(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search-repo [keyword]",
+		Short: "Search Git repositories",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var keyword string
+			if len(args) > 0 {
+				keyword = args[0]
+			}
+			return runSearchRepo(cmd, f, keyword)
+		},
+	}
+
+	return cmd
+}
+
+func runSearchRepo(cmd *cobra.Command, f *cmdutil.Factory, keyword string) error {
+	if keyword == "" {
+		if !f.Interactive {
+			return fmt.Errorf("keyword is required")
+		}
+		k, err := f.Prompter.Input("Enter search keyword:", "")
+		if err != nil {
+			return err
+		}
+		keyword = k
+	}
+
+	repos, err := f.ApiClient.SearchGitRepositories(cmd.Context(), &keyword)
+	if err != nil {
+		return fmt.Errorf("search repositories failed: %w", err)
+	}
+
+	if len(repos) == 0 {
+		if f.JSON {
+			return f.Printer.JSON([]any{})
+		}
+		f.Log.Infof("No repositories found for %q", keyword)
+		return nil
+	}
+
+	if f.JSON {
+		return f.Printer.JSON(repos)
+	}
+
+	for _, repo := range repos {
+		fmt.Printf("%s/%s (ID: %d)\n", repo.Owner, repo.Name, repo.ID)
+	}
+
+	return nil
+}

--- a/internal/cmd/service/search-repo/search_repo.go
+++ b/internal/cmd/service/search-repo/search_repo.go
@@ -17,7 +17,7 @@ func NewCmdSearchRepo(f *cmdutil.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var keyword string
 			if len(args) > 0 {
-				keyword = args[0]
+				keyword = strings.TrimSpace(args[0])
 			}
 			return runSearchRepo(cmd, f, keyword)
 		},

--- a/internal/cmd/service/search-repo/search_repo.go
+++ b/internal/cmd/service/search-repo/search_repo.go
@@ -2,6 +2,7 @@ package searchrepo
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/zeabur/cli/internal/cmdutil"
@@ -34,7 +35,10 @@ func runSearchRepo(cmd *cobra.Command, f *cmdutil.Factory, keyword string) error
 		if err != nil {
 			return err
 		}
-		keyword = k
+		keyword = strings.TrimSpace(k)
+		if keyword == "" {
+			return fmt.Errorf("keyword is required")
+		}
 	}
 
 	repos, err := f.ApiClient.SearchGitRepositories(cmd.Context(), &keyword)

--- a/internal/cmd/service/service.go
+++ b/internal/cmd/service/service.go
@@ -14,6 +14,7 @@ import (
 	serviceNetworkCmd "github.com/zeabur/cli/internal/cmd/service/network"
 	servicePortForwardCmd "github.com/zeabur/cli/internal/cmd/service/port-forward"
 	serviceRedeployCmd "github.com/zeabur/cli/internal/cmd/service/redeploy"
+	serviceSearchRepoCmd "github.com/zeabur/cli/internal/cmd/service/search-repo"
 	serviceRestartCmd "github.com/zeabur/cli/internal/cmd/service/restart"
 	serviceSuspendCmd "github.com/zeabur/cli/internal/cmd/service/suspend"
 	serviceUpdateCmd "github.com/zeabur/cli/internal/cmd/service/update"
@@ -41,6 +42,7 @@ func NewCmdService(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(serviceNetworkCmd.NewCmdPrivateNetwork(f))
 	cmd.AddCommand(servicePortForwardCmd.NewCmdPortForward(f))
 	cmd.AddCommand(serviceUpdateCmd.NewCmdUpdate(f))
+	cmd.AddCommand(serviceSearchRepoCmd.NewCmdSearchRepo(f))
 
 	return cmd
 }


### PR DESCRIPTION
Expose Git repository search as a standalone non-interactive command, so the skilled agent can search repos via bash without interactive mode.

DES-534

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new search-repo command to query Git repositories by keyword.
  * Accepts the keyword as a command argument or, when omitted, prompts interactively.
  * Returns results as either a JSON array or a formatted plaintext list showing owner/name and repository ID.
  * Gracefully reports when no repositories match the query or when a search fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->