### PR TITLE
feat: add subscription and credit to auth status

### DIFF
--- a/internal/cmd/auth/status/status.go
+++ b/internal/cmd/auth/status/status.go
@@ -54,7 +54,8 @@ func runStatus(f *cmdutil.Factory, opts *statusOptions) error {
 		return f.Printer.JSON(user)
 	}
 
-	f.Log.Infof("Logged in as %s, email: %s", user.Name, user.Email)
+	f.Log.Infof("Logged in as %s (%s), email: %s, plan: %s, credit: $%.2f",
+		user.Name, user.Username, user.Email, user.Subscription.Plan, float64(user.Credit)/100)
 
 	if opts.verbose {
 		f.Printer.Table(user.Header(), user.Rows())

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/zeabur/cli/pkg/util"
@@ -27,18 +28,26 @@ type User struct {
 	// EmailPreference map[string]bool    `json:"emailPreference" graphql:"emailPreference"`
 	AgreedAt *time.Time `json:"agreedAt" graphql:"agreedAt"`
 	// DiscordID is the user's Discord ID.
-	DiscordID *string `json:"discordID" graphql:"discordID"`
-	ID        string  `json:"_id" graphql:"_id"`
-	Name      string  `json:"name" graphql:"name"`
-	Email     string  `json:"email" graphql:"email"`
-	Username  string  `json:"username" graphql:"username"`
-	Language  string  `json:"language" graphql:"language"`
-	AvatarURL string  `json:"avatarUrl" graphql:"avatarURL"`
-	GitHubID  int64   `json:"githubID" graphql:"githubID"`
+	DiscordID    *string      `json:"discordID" graphql:"discordID"`
+	ID           string       `json:"_id" graphql:"_id"`
+	Name         string       `json:"name" graphql:"name"`
+	Email        string       `json:"email" graphql:"email"`
+	Username     string       `json:"username" graphql:"username"`
+	Language     string       `json:"language" graphql:"language"`
+	AvatarURL    string       `json:"avatarUrl" graphql:"avatarURL"`
+	ReferralCode string       `json:"referralCode" graphql:"referralCode"`
+	GitHubID     int64        `json:"githubID" graphql:"githubID"`
+	Credit       int64        `json:"credit" graphql:"credit"`
+	Subscription Subscription `json:"subscription" graphql:"subscription"`
+}
+
+// Subscription represents the user's subscription plan.
+type Subscription struct {
+	Plan string `json:"plan" graphql:"plan"`
 }
 
 func (u *User) Header() []string {
-	return []string{"ID", "Name", "Username", "Email", "Language", "RegisteredAt"}
+	return []string{"ID", "Name", "Username", "Email", "Plan", "Credit", "Language", "RegisteredAt"}
 }
 
 func (u *User) Rows() [][]string {
@@ -47,6 +56,8 @@ func (u *User) Rows() [][]string {
 	row = append(row, u.Name)
 	row = append(row, u.Username)
 	row = append(row, u.Email)
+	row = append(row, u.Subscription.Plan)
+	row = append(row, fmt.Sprintf("$%.2f", float64(u.Credit)/100))
 	row = append(row, u.Language)
 	row = append(row, util.ConvertTimeAgoString(*u.CreatedAt))
 


### PR DESCRIPTION
Show plan and credit balance in `auth status` output and JSON.

DES-530

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The status command now displays enhanced account information, including subscription plan and credit balance (shown in currency), providing a more comprehensive view of your account details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->