### PR TITLE
feat: add `server ssh-info` command for non-interactive SSH credentials

### DIFF
--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -13,6 +13,7 @@ import (
 	serverRenameCmd "github.com/zeabur/cli/internal/cmd/server/rename"
 	serverRentCmd "github.com/zeabur/cli/internal/cmd/server/rent"
 	serverSSHCmd "github.com/zeabur/cli/internal/cmd/server/ssh"
+	serverSSHInfoCmd "github.com/zeabur/cli/internal/cmd/server/sshinfo"
 	"github.com/zeabur/cli/internal/cmdutil"
 )
 
@@ -32,6 +33,7 @@ func NewCmdServer(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(serverRegionCmd.NewCmdRegion(f))
 	cmd.AddCommand(serverPlanCmd.NewCmdPlan(f))
 	cmd.AddCommand(serverSSHCmd.NewCmdSSH(f))
+	cmd.AddCommand(serverSSHInfoCmd.NewCmdSSHInfo(f))
 
 	return cmd
 }

--- a/internal/cmd/server/sshinfo/sshinfo.go
+++ b/internal/cmd/server/sshinfo/sshinfo.go
@@ -1,0 +1,121 @@
+package sshinfo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zeabur/cli/internal/cmdutil"
+)
+
+type Options struct {
+	id string
+}
+
+type SSHInfo struct {
+	IP       string `json:"ip"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func NewCmdSSHInfo(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "ssh-info [server-id]",
+		Short: "Get SSH connection info for a dedicated server",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				if opts.id != "" && opts.id != args[0] {
+					return fmt.Errorf("conflicting server IDs: arg=%q, --id=%q", args[0], opts.id)
+				}
+				opts.id = args[0]
+			}
+			return runSSHInfo(f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.id, "id", "", "Server ID")
+
+	return cmd
+}
+
+func runSSHInfo(f *cmdutil.Factory, opts *Options) error {
+	if f.Interactive && opts.id == "" {
+		return runSSHInfoInteractive(f, opts)
+	}
+	return runSSHInfoNonInteractive(f, opts)
+}
+
+func runSSHInfoInteractive(f *cmdutil.Factory, opts *Options) error {
+	servers, err := f.ApiClient.ListServers(context.Background())
+	if err != nil {
+		return fmt.Errorf("list servers failed: %w", err)
+	}
+	if len(servers) == 0 {
+		return fmt.Errorf("no servers found")
+	}
+
+	options := make([]string, len(servers))
+	for i, s := range servers {
+		location := s.IP
+		if s.City != nil && s.Country != nil {
+			location = fmt.Sprintf("%s, %s", *s.City, *s.Country)
+		} else if s.Country != nil {
+			location = *s.Country
+		}
+		options[i] = fmt.Sprintf("%s (%s)", s.Name, location)
+	}
+
+	idx, err := f.Prompter.Select("Select a server", "", options)
+	if err != nil {
+		return err
+	}
+	opts.id = servers[idx].ID
+
+	return runSSHInfoNonInteractive(f, opts)
+}
+
+func runSSHInfoNonInteractive(f *cmdutil.Factory, opts *Options) error {
+	if opts.id == "" {
+		return fmt.Errorf("--id is required")
+	}
+
+	ctx := context.Background()
+
+	server, err := f.ApiClient.GetServer(ctx, opts.id)
+	if err != nil {
+		return fmt.Errorf("get server failed: %w", err)
+	}
+
+	username := "root"
+	if server.SSHUsername != nil && *server.SSHUsername != "" {
+		username = *server.SSHUsername
+	}
+
+	var password string
+	if server.IsManaged {
+		pw, err := f.ApiClient.RevealServerPassword(ctx, opts.id)
+		if err == nil && pw != "" {
+			password = pw
+		}
+	}
+
+	info := SSHInfo{
+		IP:       server.IP,
+		Port:     server.SSHPort,
+		Username: username,
+		Password: password,
+	}
+
+	data, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("marshal failed: %w", err)
+	}
+
+	fmt.Println(string(data))
+	return nil
+}

--- a/internal/cmd/server/sshinfo/sshinfo.go
+++ b/internal/cmd/server/sshinfo/sshinfo.go
@@ -117,6 +117,8 @@ func runSSHInfoNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		return fmt.Errorf("marshal failed: %w", err)
 	}
 
-	fmt.Println(string(data)) //nolint:gosec // Intentionally outputting credentials for agent consumption
+	if _, err := fmt.Println(string(data)); err != nil { //nolint:gosec // Intentionally outputting credentials for agent consumption
+		return fmt.Errorf("write output failed: %w", err)
+	}
 	return nil
 }

--- a/internal/cmd/server/sshinfo/sshinfo.go
+++ b/internal/cmd/server/sshinfo/sshinfo.go
@@ -117,6 +117,6 @@ func runSSHInfoNonInteractive(f *cmdutil.Factory, opts *Options) error {
 		return fmt.Errorf("marshal failed: %w", err)
 	}
 
-	fmt.Println(string(data))
+	fmt.Println(string(data)) //nolint:gosec // Intentionally outputting credentials for agent consumption
 	return nil
 }

--- a/internal/cmd/server/sshinfo/sshinfo.go
+++ b/internal/cmd/server/sshinfo/sshinfo.go
@@ -81,7 +81,7 @@ func runSSHInfoInteractive(f *cmdutil.Factory, opts *Options) error {
 
 func runSSHInfoNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	if opts.id == "" {
-		return fmt.Errorf("--id is required")
+		return fmt.Errorf("server ID is required (use --id or positional server-id)")
 	}
 
 	ctx := context.Background()
@@ -99,9 +99,10 @@ func runSSHInfoNonInteractive(f *cmdutil.Factory, opts *Options) error {
 	var password string
 	if server.IsManaged {
 		pw, err := f.ApiClient.RevealServerPassword(ctx, opts.id)
-		if err == nil && pw != "" {
-			password = pw
+		if err != nil {
+			return fmt.Errorf("reveal server password failed: %w", err)
 		}
+		password = pw
 	}
 
 	info := SSHInfo{


### PR DESCRIPTION
## Summary
- Add `server ssh-info` command that outputs SSH connection info (IP, port, username, password) as JSON
- Designed for non-interactive use by the skilled agent in sandbox environments
- For managed servers, retrieves password via `RevealServerPassword` API; non-managed servers return empty password

Closes DES-633

## Test plan
- [x] `--help` displays usage correctly
- [x] Missing `--id` in non-interactive mode returns error
- [x] Invalid server ID returns `No such server` error
- [x] Managed server outputs full JSON with password
- [x] Non-managed server outputs JSON with empty password
- [x] Positional arg works (without `--id` flag)
- [x] Output is valid JSON parsable by `jq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781940074&installation_id=128583772&pr_number=245&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F245&signature=72e74714ba4fef3ca5a191c4336e10defeaf4e3b88fe8c15c21ec21a33c23441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->