### PR TITLE
fix(api): surface backend error body in upload failures

### DIFF
--- a/internal/cmd/upload/upload.go
+++ b/internal/cmd/upload/upload.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zeabur/cli/internal/cmdutil"
 	"github.com/zeabur/cli/internal/util"
 	"github.com/zeabur/cli/pkg/constant"
+	pkgutil "github.com/zeabur/cli/pkg/util"
 )
 
 type Options struct{}
@@ -100,7 +101,7 @@ func UploadZipToService(ctx context.Context, zipBytes []byte) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("failed to create upload session: status code %d", resp.StatusCode)
+		return "", pkgutil.FormatHTTPError("failed to create upload session", resp)
 	}
 
 	var uploadSession struct {
@@ -132,7 +133,7 @@ func UploadZipToService(ctx context.Context, zipBytes []byte) (string, error) {
 	defer uploadResp.Body.Close()
 
 	if uploadResp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to upload to S3: status code %d", uploadResp.StatusCode)
+		return "", pkgutil.FormatHTTPError("failed to upload to S3", uploadResp)
 	}
 
 	// Step 4: Prepare upload for deployment
@@ -164,7 +165,7 @@ func UploadZipToService(ctx context.Context, zipBytes []byte) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to prepare upload: status code %d", resp.StatusCode)
+		return "", pkgutil.FormatHTTPError("failed to prepare upload", resp)
 	}
 
 	return uploadSession.UploadID, nil

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/zeabur/cli/pkg/constant"
 	"github.com/zeabur/cli/pkg/model"
+	"github.com/zeabur/cli/pkg/util"
 )
 
 func (c *client) ListServices(ctx context.Context, projectID string, skip, limit int) (*model.Connection[model.Service], error) {
@@ -392,7 +393,7 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("failed to create upload session: status code %d", resp.StatusCode)
+		return nil, util.FormatHTTPError("failed to create upload session", resp)
 	}
 
 	var uploadSession struct {
@@ -424,7 +425,7 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	defer uploadResp.Body.Close()
 
 	if uploadResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to upload to S3: status code %d", uploadResp.StatusCode)
+		return nil, util.FormatHTTPError("failed to upload to S3", uploadResp)
 	}
 
 	// Step 4: Prepare upload for deployment
@@ -460,7 +461,7 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to prepare upload: status code %d", resp.StatusCode)
+		return nil, util.FormatHTTPError("failed to prepare upload", resp)
 	}
 
 	return nil, nil

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// FormatHTTPError reads a non-2xx HTTP response and returns an error that
+// preserves whatever the server actually said.
+//
+// The Zeabur API returns JSON bodies of the form
+//
+//	{"code": "REQUIRE_PAID_PLAN", "error": "Upload size ... exceeds ..."}
+//
+// for client-visible failures. When that shape is present, the message and
+// (if available) code are surfaced. Otherwise the raw body is included so
+// the user still has something to act on instead of a bare status code.
+//
+// action is a short verb phrase describing what failed, e.g. "create upload session".
+func FormatHTTPError(action string, resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+
+	var errResp struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {
+		if errResp.Code != "" {
+			return fmt.Errorf("%s: %s (code: %s, status: %d)", action, errResp.Error, errResp.Code, resp.StatusCode)
+		}
+		return fmt.Errorf("%s: %s (status: %d)", action, errResp.Error, resp.StatusCode)
+	}
+
+	if len(body) > 0 {
+		return fmt.Errorf("%s: status code %d, body: %s", action, resp.StatusCode, string(body))
+	}
+	return fmt.Errorf("%s: status code %d", action, resp.StatusCode)
+}

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,0 +1,76 @@
+package util_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/cli/pkg/util"
+)
+
+func TestFormatHTTPError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantSubstr []string
+	}{
+		{
+			name:       "structured error with code (REQUIRE_PAID_PLAN)",
+			statusCode: 400,
+			body:       `{"code":"REQUIRE_PAID_PLAN","error":"Upload size 53048320 bytes exceeds your plan's limit of 52428800 bytes.","limit":52428800,"content_length":53048320}`,
+			wantSubstr: []string{
+				"do thing",
+				"Upload size 53048320 bytes exceeds",
+				"code: REQUIRE_PAID_PLAN",
+				"status: 400",
+			},
+		},
+		{
+			name:       "structured error without code",
+			statusCode: 403,
+			body:       `{"error":"forbidden"}`,
+			wantSubstr: []string{"do thing", "forbidden", "status: 403"},
+		},
+		{
+			name:       "non-JSON body falls back to raw body",
+			statusCode: 502,
+			body:       "<html>Bad Gateway</html>",
+			wantSubstr: []string{"do thing", "status code 502", "<html>Bad Gateway</html>"},
+		},
+		{
+			name:       "empty body falls back to status code only",
+			statusCode: 504,
+			body:       "",
+			wantSubstr: []string{"do thing", "status code 504"},
+		},
+		{
+			name:       "JSON without error field falls back to raw body",
+			statusCode: 400,
+			body:       `{"foo":"bar"}`,
+			wantSubstr: []string{"status code 400", `{"foo":"bar"}`},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &http.Response{
+				StatusCode: tc.statusCode,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+
+			err := util.FormatHTTPError("do thing", resp)
+			assert.Error(t, err)
+			for _, s := range tc.wantSubstr {
+				assert.Contains(t, err.Error(), s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Description

The CLI's `/v2/upload`, S3 PUT, and prepare calls all swallowed the response body and returned only `status code N`. When the backend rejects an upload with a structured JSON error (e.g. `REQUIRE_PAID_PLAN` for exceeding plan upload size), users saw an opaque 400 with no clue about plan limits or how to fix it.

Surfaced by Discord thread `1513102734407106630`: same project, same CLI, succeeded at 08:04 UTC, then started failing from 08:22 UTC after the bundle crossed the 50 MiB Free Plan limit. Took ~30 min of backend trace + Stripe + entitlement spelunking on the support side to recover a cause that was literally on the wire — backend already returned:

```json
{"code":"REQUIRE_PAID_PLAN","error":"Upload size 53048320 bytes exceeds your plan's limit of 52428800 bytes. Upgrade your plan to upload larger files.","limit":52428800,"content_length":53048320}
```

#### Change

Add `util.FormatHTTPError(action string, resp *http.Response) error` which reads the body, prefers the JSON `error` / `code` fields when present, and falls back to the raw body or status code. Apply at the six call sites:

`pkg/api/service.go` (`existing_service` deploy)
1. create upload session
2. S3 PUT
3. prepare

`internal/cmd/upload/upload.go` (`new_project` upload)
1. create upload session
2. S3 PUT
3. prepare

Unit-tested across structured errors (with/without `code`), non-JSON bodies, empty bodies, and JSON bodies missing the `error` field.

#### Before / after

Before:
```
ERROR  failed to create upload session: status code 400
```

After:
```
ERROR  failed to create upload session: Upload size 53048320 bytes exceeds your plan's limit of 52428800 bytes. Upgrade your plan to upload larger files. (code: REQUIRE_PAID_PLAN, status: 400)
```

#### Out of scope

The two `UploadZipToService` implementations (`pkg/api/service.go` and `internal/cmd/upload/upload.go`) are near-duplicates and worth unifying, but that refactor is bigger than this fix.

#### Related issues & labels

- Refs SEI-717

#### Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` clean (new tests in `pkg/util/http_test.go`)
- `golangci-lint run ./pkg/util/... ./pkg/api/... ./internal/cmd/upload/...` 0 issues

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783427742&installation_id=128583772&pr_number=250&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F250&signature=a6b06abf796590df10c09ed835f8d668ae8100bf0bc5cf1cdf9db21271eeb9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting during file uploads. Failures during upload session creation, file transfer, or deployment preparation now display clearer, more informative error messages instead of only status codes.

* **Tests**
  * Added comprehensive test coverage for error message formatting across multiple failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->