### PR TITLE
fix(api): handle body read error and cap response size in FormatHTTPError

### DIFF
--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -20,7 +20,10 @@ import (
 //
 // action is a short verb phrase describing what failed, e.g. "create upload session".
 func FormatHTTPError(action string, resp *http.Response) error {
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("%s: failed to read response body (status: %d): %w", action, resp.StatusCode, err)
+	}
 
 	var errResp struct {
 		Code  string `json:"code"`


### PR DESCRIPTION
#### Description

Follow-up to #250. The review-feedback commit addressing CodeRabbit's `io.ReadAll` finding was accidentally pushed to a branch on `zeabur/cli` instead of the fork branch backing the PR, so #250 merged without it. This PR lands that commit on main.

#### Change

In `util.FormatHTTPError`:

- Stop discarding the `io.ReadAll` error — I/O failures during body read now surface as `failed to read response body (status: %d): <err>` instead of silently degrading to the bare status-code message.
- Wrap the body reader with `io.LimitReader(resp.Body, 1<<20)` to cap error-body buffering at 1 MiB, guarding against oversized error pages from proxies.

Addresses the review threads on #250 from CodeRabbit ("Handle the error from `io.ReadAll`", Major) and Copilot (unbounded read), plus the zeabur-review-agent `LimitReader` suggestion.

#### Verification

- `go build ./...` clean
- `go test ./pkg/util/...` pass (existing `TestFormatHTTPError` matrix still green)
- Manual edge-case sweep: structured JSON w/ and w/o `code`, HTML proxy error, S3 XML error, empty body, unicode message, 2 MB body truncated at 1 MiB

#### Related issues & labels

- Refs SEI-717, follow-up to #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787643&installation_id=128583772&pr_number=252&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F252&signature=c0ff50183b532044a1dbe1032220be6c2b1cd6febe1e29de704166eb3b61ae6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP error handling with safety limits on response body reads and improved error reporting for read failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->