### PR TITLE
fix(api): scale S3 upload timeout with payload size

### DIFF
--- a/internal/cmd/upload/upload.go
+++ b/internal/cmd/upload/upload.go
@@ -118,7 +118,12 @@ func UploadZipToService(ctx context.Context, zipBytes []byte) (string, error) {
 	}
 
 	// Step 3: Upload file to S3
-	uploadReq, err := http.NewRequestWithContext(ctx, uploadSession.PresignMethod, uploadSession.PresignURL, bytes.NewReader(zipBytes))
+	// The S3 PUT carries the whole zip, so the shared 30s client would cap
+	// uploads at ~14 Mbps. Give it its own deadline that scales with size.
+	uploadCtx, cancelUpload := context.WithTimeout(ctx, pkgutil.UploadTimeout(int64(len(zipBytes))))
+	defer cancelUpload()
+
+	uploadReq, err := http.NewRequestWithContext(uploadCtx, uploadSession.PresignMethod, uploadSession.PresignURL, bytes.NewReader(zipBytes))
 	if err != nil {
 		return "", fmt.Errorf("failed to create S3 upload request: %w", err)
 	}
@@ -126,7 +131,7 @@ func UploadZipToService(ctx context.Context, zipBytes []byte) (string, error) {
 	uploadReq.Header.Set("Content-Type", uploadSession.PresignHeader.ContentType)
 	uploadReq.Header.Set("Content-Length", strconv.FormatInt(int64(len(zipBytes)), 10))
 
-	uploadResp, err := client.Do(uploadReq)
+	uploadResp, err := (&http.Client{}).Do(uploadReq)
 	if err != nil {
 		return "", fmt.Errorf("failed to upload to S3: %w", err)
 	}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -410,7 +410,12 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	}
 
 	// Step 3: Upload file to S3
-	uploadReq, err := http.NewRequestWithContext(ctx, uploadSession.PresignMethod, uploadSession.PresignURL, bytes.NewReader(zipBytes))
+	// The S3 PUT carries the whole zip, so the shared 30s client would cap
+	// uploads at ~14 Mbps. Give it its own deadline that scales with size.
+	uploadCtx, cancelUpload := context.WithTimeout(ctx, util.UploadTimeout(int64(len(zipBytes))))
+	defer cancelUpload()
+
+	uploadReq, err := http.NewRequestWithContext(uploadCtx, uploadSession.PresignMethod, uploadSession.PresignURL, bytes.NewReader(zipBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create S3 upload request: %w", err)
 	}
@@ -418,7 +423,7 @@ func (c *client) UploadZipToService(ctx context.Context, projectID string, servi
 	uploadReq.Header.Set("Content-Type", uploadSession.PresignHeader.ContentType)
 	uploadReq.Header.Set("Content-Length", strconv.FormatInt(int64(len(zipBytes)), 10))
 
-	uploadResp, err := client.Do(uploadReq)
+	uploadResp, err := (&http.Client{}).Do(uploadReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload to S3: %w", err)
 	}

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -5,7 +5,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
+
+// UploadTimeout returns how long an upload of contentLength bytes is allowed
+// to take: a 2-minute floor plus one second per 256 KiB of payload.
+//
+// http.Client.Timeout covers the entire request including body transfer, so a
+// fixed timeout makes large uploads fail on slow links no matter how patient
+// the user is. The 256 KiB/s floor is deliberately conservative (~2 Mbps);
+// a 50 MiB zip gets ~5.3 minutes.
+func UploadTimeout(contentLength int64) time.Duration {
+	return 2*time.Minute + time.Duration(contentLength/(256*1024))*time.Second
+}
 
 // FormatHTTPError reads a non-2xx HTTP response and returns an error that
 // preserves whatever the server actually said.

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zeabur/cli/pkg/util"
@@ -71,6 +72,29 @@ func TestFormatHTTPError(t *testing.T) {
 			for _, s := range tc.wantSubstr {
 				assert.Contains(t, err.Error(), s)
 			}
+		})
+	}
+}
+
+func TestUploadTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		size int64
+		want time.Duration
+	}{
+		{"zero size gets the 2min floor", 0, 2 * time.Minute},
+		{"tiny payload still gets the floor", 1024, 2 * time.Minute},
+		{"1 MiB adds 4s over the floor", 1 << 20, 2*time.Minute + 4*time.Second},
+		{"50 MiB scales to ~5.3 min", 50 << 20, 2*time.Minute + 200*time.Second},
+		{"1 GiB scales to ~70 min", 1 << 30, 2*time.Minute + 4096*time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, util.UploadTimeout(tc.size))
 		})
 	}
 }


### PR DESCRIPTION
#### Problem

`zeabur deploy` / `zeabur upload` intermittently fail with:

```
ERROR failed to upload to S3: Put "https://zeabur-uploads.s3.ap-east-1.amazonaws.com/...":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The upload flow shares a single `http.Client{Timeout: 30 * time.Second}` across three requests:

```
POST /v2/upload          (small JSON)        — 30s fine
PUT  S3 presigned URL    (entire zip body)   — 30s caps throughput at ~14 Mbps for 50 MiB ← bug
POST /v2/upload/{id}/prepare (small JSON)    — 30s fine
```

`http.Client.Timeout` covers the full request **including body transfer**, so large uploads always fail on slow links and there is no flag to raise the limit. Forum report: user in Taiwan uploading ~50 MiB, 12 failures vs 3 successes in one evening (failures clustered at residential peak hours); they gave up and switched to GitHub-based deploy.

#### Prior art

- **AWS SDK for Go v2** sets no `http.Client.Timeout` for S3 transfers — cancellation is context-driven, sized to the operation.
- **rclone** deliberately uses an idle/chunk timeout instead of a total-transfer deadline for the same reason: a fixed total timeout punishes large payloads on slow links.

#### Solution

Keep the 30s client for the two small API calls. Give the S3 PUT its own context deadline that scales with payload size via `util.UploadTimeout`:

```go
// 2-minute floor + 1s per 256 KiB (~2 Mbps floor); 50 MiB → ~5.3 min
uploadCtx, cancel := context.WithTimeout(ctx, util.UploadTimeout(int64(len(zipBytes))))
```

Applied identically to both copies of the flow (`pkg/api/service.go` and `internal/cmd/upload/upload.go`).

#### Why not a flag?

A `--upload-timeout` flag pushes the failure onto the user (they only learn about it after the error). A size-scaled ceiling fixes the common case with zero configuration; a flag can still be added later if someone hits the conservative floor.

#### Caveat verified

Presigned URL expiry is signed server-side at 30 minutes (`upload_v2.go`: `s3.WithPresignExpires(30*time.Minute)`). The PUT starts seconds after signing and S3 validates the signature at request start, so the upload window is safe. The timeout only exceeds 30 min beyond ~420 MiB, far above plan limits.

#### Validation

- TDD: `TestUploadTimeout` written first (5 cases: floor, scaling at 1 MiB / 50 MiB / 1 GiB)
- `go build ./...`, `go vet ./...`, `go test ./...` all clean
- Behavioral check against a slow mock server: old pattern reproduces the exact reported error; new pattern survives the slow window and still enforces its own deadline when truly stuck

#### Related issues & labels

- Refs PLA-1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783845216&installation_id=128583772&pr_number=253&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F253&signature=fc2ba33d84be20449fab6e5a99a5a8414b0ce9c87ec9b6893321aedd457f5d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload operations now use intelligent, size-based timeout management that adjusts duration according to file size, improving reliability for large transfers.

* **Tests**
  * Added tests validating upload timeout behavior across various file sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->