### PR TITLE
feat: make server commands respect workspace context

### DIFF
--- a/internal/cmd/server/get/get.go
+++ b/internal/cmd/server/get/get.go
@@ -44,7 +44,7 @@ func runGet(f *cmdutil.Factory, opts *Options) error {
 
 func runGetInteractive(f *cmdutil.Factory, opts *Options) error {
 	if opts.id == "" {
-		servers, err := f.ApiClient.ListServers(context.Background())
+		servers, err := f.ApiClient.ListServers(context.Background(), f.CurrentOwnerID())
 		if err != nil {
 			return fmt.Errorf("list servers failed: %w", err)
 		}

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -23,7 +23,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runList(f *cmdutil.Factory) error {
-	servers, err := f.ApiClient.ListServers(context.Background())
+	servers, err := f.ApiClient.ListServers(context.Background(), f.CurrentOwnerID())
 	if err != nil {
 		return fmt.Errorf("list servers failed: %w", err)
 	}

--- a/internal/cmd/server/reboot/reboot.go
+++ b/internal/cmd/server/reboot/reboot.go
@@ -46,7 +46,7 @@ func runReboot(f *cmdutil.Factory, opts *Options) error {
 
 func runRebootInteractive(f *cmdutil.Factory, opts *Options) error {
 	if opts.id == "" {
-		servers, err := f.ApiClient.ListServers(context.Background())
+		servers, err := f.ApiClient.ListServers(context.Background(), f.CurrentOwnerID())
 		if err != nil {
 			return fmt.Errorf("list servers failed: %w", err)
 		}

--- a/internal/cmd/server/rename/rename.go
+++ b/internal/cmd/server/rename/rename.go
@@ -47,7 +47,7 @@ func runRename(f *cmdutil.Factory, opts *Options) error {
 
 func runRenameInteractive(f *cmdutil.Factory, opts *Options) error {
 	if opts.id == "" {
-		servers, err := f.ApiClient.ListServers(context.Background())
+		servers, err := f.ApiClient.ListServers(context.Background(), f.CurrentOwnerID())
 		if err != nil {
 			return fmt.Errorf("list servers failed: %w", err)
 		}

--- a/internal/cmd/server/ssh/ssh.go
+++ b/internal/cmd/server/ssh/ssh.go
@@ -47,7 +47,7 @@ func runSSH(f *cmdutil.Factory, opts *Options) error {
 
 func runSSHInteractive(f *cmdutil.Factory, opts *Options) error {
 	if opts.id == "" {
-		servers, err := f.ApiClient.ListServers(context.Background())
+		servers, err := f.ApiClient.ListServers(context.Background(), f.CurrentOwnerID())
 		if err != nil {
 			return fmt.Errorf("list servers failed: %w", err)
 		}

--- a/internal/cmd/server/sshinfo/sshinfo.go
+++ b/internal/cmd/server/sshinfo/sshinfo.go
@@ -51,7 +51,7 @@ func runSSHInfo(f *cmdutil.Factory, opts *Options) error {
 }
 
 func runSSHInfoInteractive(f *cmdutil.Factory, opts *Options) error {
-	servers, err := f.ApiClient.ListServers(context.Background())
+	servers, err := f.ApiClient.ListServers(context.Background(), f.CurrentOwnerID())
 	if err != nil {
 		return fmt.Errorf("list servers failed: %w", err)
 	}

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -60,7 +60,7 @@ type (
 	}
 
 	ServerAPI interface {
-		ListServers(ctx context.Context) (model.ServerListItems, error)
+		ListServers(ctx context.Context, ownerID string) (model.ServerListItems, error)
 		GetServer(ctx context.Context, id string) (*model.ServerDetail, error)
 		RebootServer(ctx context.Context, id string) error
 		RenameServer(ctx context.Context, id, name string) error

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -7,16 +7,25 @@ import (
 	"github.com/zeabur/cli/pkg/model"
 )
 
-func (c *client) ListServers(ctx context.Context) (model.ServerListItems, error) {
-	var query struct {
-		Servers model.ServerListItems `graphql:"servers"`
+func (c *client) ListServers(ctx context.Context, ownerID string) (model.ServerListItems, error) {
+	if ownerID == "" {
+		var query struct {
+			Servers model.ServerListItems `graphql:"servers"`
+		}
+		if err := c.Query(ctx, &query, nil); err != nil {
+			return nil, err
+		}
+		return query.Servers, nil
 	}
 
-	err := c.Query(ctx, &query, nil)
-	if err != nil {
+	var query struct {
+		Servers model.ServerListItems `graphql:"servers(ownerID: $ownerID)"`
+	}
+	if err := c.Query(ctx, &query, V{
+		"ownerID": ObjectID(ownerID),
+	}); err != nil {
 		return nil, err
 	}
-
 	return query.Servers, nil
 }
 


### PR DESCRIPTION
## Summary
- `ListServers` now accepts `ownerID` and passes it to `servers(ownerID:)` GraphQL query, matching the pattern used by `ListProjects`
- All server subcommands (`list`, `get`, `reboot`, `ssh`, `sshinfo`, `rename`) now pass `f.CurrentOwnerID()` so they return the correct workspace's servers

## Context
When using `--workspace` or `workspace switch`, server commands still returned personal servers because `ListServers` didn't pass the owner context to the backend. This is a sub-task of DES-715 (team-level agent quota).

Closes DES-718

## Test plan
- [ ] `zeabur server list` returns personal servers (no workspace set)
- [ ] `zeabur server list --workspace <teamId>` returns team servers
- [ ] `zeabur workspace switch <team>` then `zeabur server list` returns team servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784261161&installation_id=128583772&pr_number=256&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F256&signature=91a029ff1e8f7182360cea62e3c088e87f892fec7ad9679706b493add0ffdce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Server management commands (list, get, reboot, rename, SSH, and SSH info) now correctly display only servers owned by the current user instead of all available servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->