### PR TITLE
fix(cmd/variable): preserve special characters in values

### DIFF
--- a/internal/cmd/variable/create/create.go
+++ b/internal/cmd/variable/create/create.go
@@ -16,6 +16,7 @@ type Options struct {
 	id            string
 	name          string
 	environmentID string
+	rawKeys       []string
 	keys          map[string]string
 	skipConfirm   bool
 	inputDone     bool
@@ -29,6 +30,13 @@ func NewCmdCreateVariable(f *cmdutil.Factory) *cobra.Command {
 		Short: "create variable(s)",
 		Long:  `Create variable(s) for a service`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !f.Interactive {
+				keys, err := cmdutil.ParseKeyValuePairs(opts.rawKeys)
+				if err != nil {
+					return err
+				}
+				opts.keys = keys
+			}
 			return runCreateVariable(f, opts)
 		},
 	}
@@ -36,7 +44,7 @@ func NewCmdCreateVariable(f *cmdutil.Factory) *cobra.Command {
 	util.AddServiceParam(cmd, &opts.id, &opts.name)
 	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, "Skip confirmation")
-	cmd.Flags().StringToStringVarP(&opts.keys, "key", "k", nil, "Key value pair of the variable")
+	cmd.Flags().StringArrayVarP(&opts.rawKeys, "key", "k", nil, "Key value pair of the variable")
 
 	return cmd
 }

--- a/internal/cmd/variable/create/create_test.go
+++ b/internal/cmd/variable/create/create_test.go
@@ -1,0 +1,26 @@
+package create
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKeyFlagPreservesValues(t *testing.T) {
+	cmd := NewCmdCreateVariable(nil)
+	want := []string{
+		"DATABASE_URL=${POSTGRESQL.POSTGRES_CONNECTION_STRING}",
+		"OPTIONS=one,two",
+	}
+
+	if err := cmd.ParseFlags([]string{"--key", want[0], "--key", want[1]}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	got, err := cmd.Flags().GetStringArray("key")
+	if err != nil {
+		t.Fatalf("GetStringArray() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("key values = %#v, want %#v", got, want)
+	}
+}

--- a/internal/cmd/variable/update/update.go
+++ b/internal/cmd/variable/update/update.go
@@ -15,6 +15,7 @@ type Options struct {
 	id            string
 	name          string
 	environmentID string
+	rawKeys       []string
 	keys          map[string]string
 	updatedKeys   []string // tracks only the keys the user explicitly changed
 	skipConfirm   bool
@@ -38,6 +39,13 @@ func NewCmdUpdateVariable(f *cmdutil.Factory) *cobra.Command {
 		Short: "update variable(s)",
 		Long:  `update variable(s) for a service`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !f.Interactive {
+				keys, err := cmdutil.ParseKeyValuePairs(opts.rawKeys)
+				if err != nil {
+					return err
+				}
+				opts.keys = keys
+			}
 			return runUpdateVariable(f, opts)
 		},
 	}
@@ -45,7 +53,7 @@ func NewCmdUpdateVariable(f *cmdutil.Factory) *cobra.Command {
 	util.AddServiceParam(cmd, &opts.id, &opts.name)
 	util.AddEnvOfServiceParam(cmd, &opts.environmentID)
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, "Skip confirmation")
-	cmd.Flags().StringToStringVarP(&opts.keys, "key", "k", nil, "Key value pair of the variable")
+	cmd.Flags().StringArrayVarP(&opts.rawKeys, "key", "k", nil, "Key value pair of the variable")
 
 	return cmd
 }

--- a/internal/cmd/variable/update/update_test.go
+++ b/internal/cmd/variable/update/update_test.go
@@ -1,0 +1,26 @@
+package update
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKeyFlagPreservesValues(t *testing.T) {
+	cmd := NewCmdUpdateVariable(nil)
+	want := []string{
+		"DATABASE_URL=${POSTGRESQL.POSTGRES_CONNECTION_STRING}",
+		"OPTIONS=one,two",
+	}
+
+	if err := cmd.ParseFlags([]string{"--key", want[0], "--key", want[1]}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	got, err := cmd.Flags().GetStringArray("key")
+	if err != nil {
+		t.Fatalf("GetStringArray() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("key values = %#v, want %#v", got, want)
+	}
+}

--- a/internal/cmdutil/keyvalue.go
+++ b/internal/cmdutil/keyvalue.go
@@ -1,0 +1,22 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseKeyValuePairs converts KEY=VALUE arguments into a map without
+// interpreting characters in the value.
+func ParseKeyValuePairs(values []string) (map[string]string, error) {
+	pairs := make(map[string]string, len(values))
+
+	for _, value := range values {
+		key, val, found := strings.Cut(value, "=")
+		if !found || key == "" {
+			return nil, fmt.Errorf("invalid key value pair %q: expected KEY=VALUE format", value)
+		}
+		pairs[key] = val
+	}
+
+	return pairs, nil
+}

--- a/internal/cmdutil/keyvalue_test.go
+++ b/internal/cmdutil/keyvalue_test.go
@@ -1,0 +1,58 @@
+package cmdutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseKeyValuePairs(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:   "preserves variable reference",
+			values: []string{"DATABASE_URL=${POSTGRESQL.POSTGRES_CONNECTION_STRING}"},
+			want:   map[string]string{"DATABASE_URL": "${POSTGRESQL.POSTGRES_CONNECTION_STRING}"},
+		},
+		{
+			name:   "preserves commas and equals signs",
+			values: []string{"OPTIONS=one,two", "TOKEN=header=payload=signature"},
+			want:   map[string]string{"OPTIONS": "one,two", "TOKEN": "header=payload=signature"},
+		},
+		{
+			name:   "allows empty value",
+			values: []string{"EMPTY="},
+			want:   map[string]string{"EMPTY": ""},
+		},
+		{
+			name:   "last duplicate wins",
+			values: []string{"KEY=first", "KEY=second"},
+			want:   map[string]string{"KEY": "second"},
+		},
+		{
+			name:    "rejects missing separator",
+			values:  []string{"INVALID"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects empty key",
+			values:  []string{"=value"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseKeyValuePairs(tt.values)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseKeyValuePairs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseKeyValuePairs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- replace Cobra `StringToString` flags with raw `StringArray` arguments for variable create and update
- split each `KEY=VALUE` entry only on the first `=` so `${...}`, commas, and embedded equals signs are preserved
- validate malformed entries and add regression tests for both commands and the shared parser

## Testing

- `go test ./...`
- `go vet ./...`

Closes #201

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786722319&installation_id=128583772&pr_number=266&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F266&signature=4b9ee6d735174073ddf45c41ad5c65939c23e8cfd34d75a396ec7ecbb3452603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Variable creation and updates now support multiple `--key`/`-k` arguments in the same command.
  * Key/value values are preserved correctly, including commas, additional equals signs, variable references, and empty values.
  * Invalid key/value formats now produce clear errors.
  * When a key is provided more than once, the last value takes precedence.

* **Tests**
  * Added coverage for repeated flags and key/value parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->