### PR TITLE
feat(server): show whether a server runs ZeaburOS in `get` and `list`

### DIFF
--- a/pkg/model/server.go
+++ b/pkg/model/server.go
@@ -1,9 +1,58 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
+
+// OS labels reported for a server. Renting and reinstalling provision the base
+// OS only, so a machine without Zeabur services is a first-class outcome — it
+// just cannot host Zeabur projects until they are installed.
+const (
+	OSZeaburOS = "ZeaburOS"
+	OSUbuntu   = "Ubuntu"
+)
+
+// serverOS derives the machine's OS from hasK3s.
+//
+// hasK3s is three-state, and the third state is the trap:
+//
+//   - true  — Zeabur services are installed.
+//   - false — explicitly none.
+//   - nil   — a legacy server, which *does* have them. The backend infers this
+//     from the server's certificate data, but the GraphQL field exposes the raw
+//     column, so the inference never reaches the wire.
+//
+// So the test is `== false`, never `!hasK3s`: the latter would sweep every
+// legacy server in and mislabel it as a plain VPS. Mirrors isCleanMachine() in
+// the dashboard.
+//
+// Ubuntu is what Zeabur provisions when renting or reinstalling, so it is
+// accurate for every machine that reached this state through Zeabur. A
+// self-registered server running some other distribution would be labelled
+// Ubuntu too, but such a server has Zeabur services installed at registration
+// and therefore reports ZeaburOS instead.
+func serverOS(hasK3s *bool) string {
+	if hasK3s != nil && !*hasK3s {
+		return OSUbuntu
+	}
+	return OSZeaburOS
+}
+
+// formatUsage renders a used/total pair, or an em dash when the total is zero.
+//
+// Zero total is the contract for "not measured" — a real machine cannot have
+// zero cores, zero memory or zero disk. Printing "0/0" would read as a machine
+// in trouble rather than one whose metrics have not been collected yet.
+// The unit is always spelled out: the backend reports CPU in millicores, so a
+// 4-core machine reads as 4000 and would otherwise look like 4000 cores.
+func formatUsage(used, total int, unit string) string {
+	if total == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%d/%d %s", used, total, unit)
+}
 
 type Server struct {
 	ID      string  `graphql:"_id"`
@@ -74,7 +123,7 @@ type ServerDetail struct {
 	Name               string              `graphql:"name"`
 	IP                 string              `graphql:"ip"`
 	SSHPort            int                 `graphql:"sshPort"`
-	SSHUsername         *string             `graphql:"sshUsername"`
+	SSHUsername        *string             `graphql:"sshUsername"`
 	Country            *string             `graphql:"country"`
 	City               *string             `graphql:"city"`
 	Continent          *string             `graphql:"continent"`
@@ -84,6 +133,18 @@ type ServerDetail struct {
 	Status             ServerStatus        `graphql:"status"`
 	ProviderInfo       *ServerProviderInfo `graphql:"providerInfo"`
 	Events             []ServerEvent       `graphql:"events"`
+	HasK3s             *bool               `graphql:"hasK3s"`
+}
+
+// MarshalJSON adds the derived `os` field so machine-readable output states the
+// machine's kind outright, instead of leaving every caller to rediscover that
+// hasK3s is three-state.
+func (s ServerDetail) MarshalJSON() ([]byte, error) {
+	type alias ServerDetail
+	return json.Marshal(struct {
+		alias
+		OS string `json:"os"`
+	}{alias(s), serverOS(s.HasK3s)})
 }
 
 type ServerProviderInfo struct {
@@ -98,7 +159,7 @@ type ServerEvent struct {
 }
 
 func (s *ServerDetail) Header() []string {
-	return []string{"ID", "Name", "IP", "Provider", "Location", "Status", "VM Status", "CPU", "Memory", "Disk", "Managed", "Created At"}
+	return []string{"ID", "Name", "IP", "Provider", "Location", "Status", "VM Status", "OS", "CPU", "Memory", "Disk", "Managed", "Created At"}
 }
 
 func (s *ServerDetail) Rows() [][]string {
@@ -126,9 +187,9 @@ func (s *ServerDetail) Rows() [][]string {
 		managed = "Yes"
 	}
 
-	cpu := fmt.Sprintf("%d/%d", s.Status.UsedCPU, s.Status.TotalCPU)
-	memory := fmt.Sprintf("%d/%d MB", s.Status.UsedMemory, s.Status.TotalMemory)
-	disk := fmt.Sprintf("%d/%d MB", s.Status.UsedDisk, s.Status.TotalDisk)
+	cpu := formatUsage(s.Status.UsedCPU, s.Status.TotalCPU, "m")
+	memory := formatUsage(s.Status.UsedMemory, s.Status.TotalMemory, "MB")
+	disk := formatUsage(s.Status.UsedDisk, s.Status.TotalDisk, "MB")
 
 	return [][]string{
 		{
@@ -139,6 +200,7 @@ func (s *ServerDetail) Rows() [][]string {
 			location,
 			status,
 			s.Status.VMStatus,
+			serverOS(s.HasK3s),
 			cpu,
 			memory,
 			disk,
@@ -217,12 +279,22 @@ type ServerListItem struct {
 	ProvisioningStatus *string             `graphql:"provisioningStatus"`
 	Status             ServerStatus        `graphql:"status"`
 	ProviderInfo       *ServerProviderInfo `graphql:"providerInfo"`
+	HasK3s             *bool               `graphql:"hasK3s"`
+}
+
+// MarshalJSON adds the derived `os` field. See ServerDetail.MarshalJSON.
+func (s ServerListItem) MarshalJSON() ([]byte, error) {
+	type alias ServerListItem
+	return json.Marshal(struct {
+		alias
+		OS string `json:"os"`
+	}{alias(s), serverOS(s.HasK3s)})
 }
 
 type ServerListItems []ServerListItem
 
 func (s ServerListItems) Header() []string {
-	return []string{"ID", "Name", "IP", "Provider", "Location", "Status", "VM Status"}
+	return []string{"ID", "Name", "IP", "Provider", "Location", "Status", "VM Status", "OS"}
 }
 
 func (s ServerListItems) Rows() [][]string {
@@ -255,6 +327,7 @@ func (s ServerListItems) Rows() [][]string {
 			location,
 			status,
 			item.Status.VMStatus,
+			serverOS(item.HasK3s),
 		}
 	}
 	return rows

--- a/pkg/model/server_test.go
+++ b/pkg/model/server_test.go
@@ -1,0 +1,128 @@
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zeabur/cli/pkg/model"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// indexOf returns the column index of name in header, failing the test when the
+// column is missing — keeps the assertions below readable and order-independent.
+func indexOf(t *testing.T, header []string, name string) int {
+	t.Helper()
+	for i, h := range header {
+		if h == name {
+			return i
+		}
+	}
+	t.Fatalf("column %q not found in header %v", name, header)
+	return -1
+}
+
+func TestServerListItemsOSColumn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		hasK3s *bool
+		want   string
+	}{
+		{name: "k3s installed", hasK3s: ptr(true), want: "ZeaburOS"},
+		{name: "explicitly no k3s", hasK3s: ptr(false), want: "Ubuntu"},
+		// A legacy server predates the field and does have Zeabur services; the
+		// backend infers that from certificate data but exposes the raw column,
+		// so null must never be read as "no k3s".
+		{name: "legacy server reports null", hasK3s: nil, want: "ZeaburOS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			items := model.ServerListItems{{ID: "abc", Name: "s", HasK3s: tt.hasK3s}}
+			rows := items.Rows()
+			require.Len(t, rows, 1)
+			assert.Equal(t, tt.want, rows[0][indexOf(t, items.Header(), "OS")])
+		})
+	}
+}
+
+func TestServerDetailOSColumn(t *testing.T) {
+	t.Parallel()
+
+	server := &model.ServerDetail{ID: "abc", Name: "s", HasK3s: ptr(false)}
+	rows := server.Rows()
+	require.Len(t, rows, 1)
+	assert.Equal(t, "Ubuntu", rows[0][indexOf(t, server.Header(), "OS")])
+}
+
+func TestServerDetailResourceColumns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders usage when measured", func(t *testing.T) {
+		t.Parallel()
+
+		server := &model.ServerDetail{
+			Status: model.ServerStatus{
+				UsedCPU: 1000, TotalCPU: 4000,
+				UsedMemory: 512, TotalMemory: 2048,
+				UsedDisk: 3000, TotalDisk: 40000,
+			},
+		}
+		row := server.Rows()[0]
+		header := server.Header()
+		// CPU is millicores, so the unit must be spelled out — a 4-core machine
+		// reports 4000 and would otherwise read as 4000 cores.
+		assert.Equal(t, "1000/4000 m", row[indexOf(t, header, "CPU")])
+		assert.Equal(t, "512/2048 MB", row[indexOf(t, header, "Memory")])
+		assert.Equal(t, "3000/40000 MB", row[indexOf(t, header, "Disk")])
+	})
+
+	// A real machine cannot have zero cores, so a zero total means the metrics
+	// were never collected. Printing "0/0" would read as a machine in trouble.
+	t.Run("renders a dash when not measured", func(t *testing.T) {
+		t.Parallel()
+
+		server := &model.ServerDetail{}
+		row := server.Rows()[0]
+		header := server.Header()
+		assert.Equal(t, "—", row[indexOf(t, header, "CPU")])
+		assert.Equal(t, "—", row[indexOf(t, header, "Memory")])
+		assert.Equal(t, "—", row[indexOf(t, header, "Disk")])
+	})
+}
+
+func TestServerJSONCarriesOS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("detail", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := json.Marshal(&model.ServerDetail{ID: "abc", HasK3s: ptr(false)})
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "Ubuntu", got["os"])
+		assert.Equal(t, "abc", got["ID"])
+		// The raw three-state field stays available for callers that need it.
+		assert.Equal(t, false, got["HasK3s"])
+	})
+
+	t.Run("list", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := json.Marshal(model.ServerListItems{{ID: "abc", HasK3s: ptr(true)}})
+		require.NoError(t, err)
+
+		var got []map[string]any
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Len(t, got, 1)
+		assert.Equal(t, "ZeaburOS", got[0]["os"])
+	})
+}


### PR DESCRIPTION
## Background

Renting a server provisions the base OS only — installing Zeabur services is a separate, optional step. Whether a machine runs **ZeaburOS** is therefore a real branch point: it determines whether the machine can host Zeabur projects at all.

Neither `server get` nor `server list` exposed this. Given a server ID, there was no way to tell the two apart short of running a `kubectl` command over SSH and checking whether it fails with `command not found` — a wasted round trip that also cannot be done *before* deciding whether to create a project on that machine.

`hasK3s` has been on the `Server` type in the GraphQL schema all along, so this is a CLI-side change with no backend work. Queries are generated by reflecting over struct tags, so adding the field to the model puts it in the query — `pkg/api/server.go` is untouched.

## Changes

- `server get` and `server list` gain an **OS** column (`ZeaburOS` / `Ubuntu`).
- JSON output carries a derived **`os`** string alongside the raw `HasK3s`. This is the main point of the change — callers should not have to rediscover the field's three-state semantics. The table column is a convenience on top.

```console
$ zeabur server list -i=false
     ID              NAME              IP           PROVIDER   LOCATION    STATUS   VM STATUS   OS
 ...............   my-server     ..............   Akamai     Tokyo, JP   Online   RUNNING     ZeaburOS
```

```console
$ zeabur server list -i=false --json | jq '.[] | {Name, HasK3s, os}'
{ "Name": "my-server", "HasK3s": true, "os": "ZeaburOS" }
```

### `hasK3s` is three-state, and the third state is a trap

| Value | Meaning |
|---|---|
| `true` | Zeabur services are installed |
| `false` | Explicitly none |
| `null` | A legacy server — which **does** have them |

The backend infers the legacy case from the server's certificate data, but the GraphQL field is bound to the raw column, so that inference never reaches the wire. The test is therefore `== false`, never `!hasK3s`: the latter would sweep every legacy server in and quietly mislabel it. This mirrors the equivalent contract in the dashboard, and is pinned by unit tests.

### Two fixes to the resource columns, while in the area

- **A zero total now renders as `—` instead of `0/0 MB`.** Zero total is the contract for "not measured" — a real machine cannot have zero cores. Printing `0/0` reads as a machine in trouble rather than one whose metrics have not been collected yet. Servers without Zeabur services only recently started reporting CPU/RAM/disk, so this path is newly reachable.
- **CPU now carries its unit (`m`).** The backend reports millicores, so a 4-core machine reads as `4000`; without a unit that looks like 4000 cores. Matches the k8s-style units the dashboard already uses.

## Verification

- `go build ./...` and `go test ./...` pass. New `pkg/model/server_test.go` covers all three states (including `null`), the `—` rendering, and that JSON carries `os` while retaining the raw `HasK3s`.
- Table and JSON output verified against real servers. All machines available for testing reported `hasK3s: true`; the `false` and `null` states are covered by unit tests.

## Out of scope

- Memory and disk keep the backend's MB rather than switching to `Gi`.
- Choosing an OS at rent time is handled outside the CLI and is not added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)