### PR TITLE
fix(npm): propagate CLI exit code from npm wrapper (related to #214)

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "child_process";
+import { spawnSync } from "child_process";
 import os from "os";
 import { fileURLToPath } from "url";
 
@@ -40,5 +40,14 @@ function getArch() {
     const pathToBinary = fileURLToPath(new URL(`./zeabur_${platform}_${arch}/zeabur${platform === "windows" ? ".exe" : ""}`, import.meta.url));
     const args = process.argv.slice(2);
 
-    execFileSync(pathToBinary, args, { stdio: "inherit" });
+    const result = spawnSync(pathToBinary, args, { stdio: "inherit" });
+
+    if (result.error) {
+        console.error(`Failed to run ${pathToBinary}: ${result.error.message}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    // status is null when the binary was terminated by a signal.
+    process.exitCode = result.status === null ? 1 : result.status;
 })()


### PR DESCRIPTION
## Summary

Related to #214. The quoting half of that issue was already fixed in merged #215 (`execFileSync` with argv array). This PR addresses the **residual exit-code propagation** when the npm wrapper shells out to the platform binary.

`execFileSync` throws on non-zero CLI exit, so `npx zeabur service exec` (and similar) printed a Node stack trace and always exited `1`, discarding deliberate exit codes from commands like `internal/cmd/service/exec/exec.go` and `internal/cmd/server/exec/exec.go`.

Switch to `spawnSync` + `process.exitCode` so the wrapper forwards the binary's status (including signal-terminated runs).

## AI disclosure

AI-assisted patch; human-reviewed by Stan Shih (stantheman0128) before publish.

## Verification / Evidence

Windows 11, fake binary harness (same argv-preservation cases as #214 discussion):

```text
# Before (origin/main npm/index.js with execFileSync):
#   exit 3 -> wrapper exits 1 + Node stack trace
#   exit 137 -> wrapper exits 1 + Node stack trace

# After (spawnSync + process.exitCode):
#   exit 3 -> 3
#   exit 137 -> 137
#   5/5 argv cases pass (nested quotes, backslashes, empty arg, shell metachars literal)
#   ENOENT -> single-line error, exit 1 (no stack)

go test ./...   # green
```

Published npm 0.21.0 tarball on registry also carries the #215 argv fix; this PR is only the exit-code half.

## What was not tested

- Live `npx zeabur` against a remote Zeabur API (local fake-binary harness only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788398591&installation_model_id=20298&pr_number=268&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F268&signature=c54a97e898968c2753d33fff0ba3ac5a5252bf2dd3dd1296c191db15a9196ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->