### PR TITLE
fix(main): exit non-zero when Cobra returns an error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,10 @@ var (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	factory := initFactory()
 
 	rootCmd, err := root.NewCmdRoot(factory, version, commit, date)
@@ -33,14 +37,15 @@ func main() {
 		os.Args = append([]string{os.Args[0], "deploy"}, os.Args[1:]...)
 	}
 
-	// log errors
 	if err := rootCmd.Execute(); err != nil {
 		// when some errors occur(such as args dis-match), the log may not be initialized
 		if factory.Log == nil {
 			factory.Log = log.NewInfoLevel()
 		}
 		factory.Log.Error(err)
+		return 1
 	}
+	return 0
 }
 
 // init factory, including config, auth, etc.

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRun_UnknownSubcommandReturnsNonZero(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	os.Args = []string{"zeabur", "this-subcommand-does-not-exist-zeabur-cli-test"}
+
+	if code := run(); code == 0 {
+		t.Fatalf("run() = %d, want non-zero when Cobra returns an error", code)
+	}
+}
+
+func TestRun_VersionReturnsZero(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	os.Args = []string{"zeabur", "version"}
+
+	if code := run(); code != 0 {
+		t.Fatalf("run() = %d, want 0 for zeabur version", code)
+	}
+}


### PR DESCRIPTION
## Summary

When a Cobra subcommand returned an error, `main` logged it but the process still exited `0`. That broke shell scripts and CI that rely on `$?` after `zeabur ...` failures (for example invalid flags or missing required args).

Refactor to `run() int` and `os.Exit(run())` so any `Execute()` error returns exit code `1`. Subcommands that call `os.Exit` with a remote command status (`service exec`, `server exec`) are unchanged.

Related to [#268](https://github.com/zeabur/cli/pull/268) (npm wrapper exit propagation); this fixes the Go entrypoint path.

## AI disclosure

AI-assisted patch; human-reviewed by Stan Shih (stantheman0128) before publish.

## Verification / Evidence

```text
go test ./cmd/... -v -count=1
# TestRun_UnknownSubcommandReturnsNonZero PASS (run() non-zero)
# TestRun_VersionReturnsZero PASS (run() == 0)

go test ./... -count=1   # green
```

Before: `go run ./cmd/main.go this-subcommand-does-not-exist` exited 0 on Windows 11.
After: same invocation exits 1.

## What was not tested

- Live `npx zeabur` end-to-end against the published npm tarball (local `go run` only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/cli/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788400768&installation_model_id=20298&pr_number=269&repository=zeabur%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fcli%2Fpull%2F269&signature=6c07227e61c66dc23338cc0a946320fbbb6c42d75361fc713fa65732b8235ca6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->