### PR TITLE
fix(npm): mirror the binary's exit status instead of throwing a Node stack trace

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -40,5 +40,21 @@ function getArch() {
     const pathToBinary = fileURLToPath(new URL(`./zeabur_${platform}_${arch}/zeabur${platform === "windows" ? ".exe" : ""}`, import.meta.url));
     const args = process.argv.slice(2);
 
-    execFileSync(pathToBinary, args, { stdio: "inherit" });
+    // This wrapper must be transparent: the binary already wrote its own
+    // stdout/stderr (stdio: "inherit"), so on failure we only mirror its exit
+    // status. Letting execFileSync throw would print a Node stack trace with
+    // `stdout: null, stderr: null` and replace the real exit code with 1.
+    try {
+        execFileSync(pathToBinary, args, { stdio: "inherit" });
+    } catch (e) {
+        if (typeof e.status === "number") {
+            process.exit(e.status);
+        }
+        if (e.signal) {
+            // Shell convention for a process killed by a signal.
+            process.exit(128 + (os.constants.signals[e.signal] ?? 0));
+        }
+        console.error(e.message ?? String(e));
+        process.exit(1);
+    }
 })()


### PR DESCRIPTION
## Summary
- `npm/index.js` (what `npx zeabur` runs) let `execFileSync` throw on any non-zero exit: Node printed an uncaught-exception stack trace with `stdout: null, stderr: null` (stdio is inherited, so the real output had already been printed) and the exit code collapsed to 1. An agent reading that concluded "exec produced nothing" instead of seeing psql's real `role "postgres" does not exist` (exit 2) — DES-909.
- The wrapper now mirrors the binary's exit status; a signal death exits `128 + signal`; a spawn failure (missing binary) prints one line and exits 1. stdio passes through exactly as before.

## Test plan
- [x] Manually staged `index.js` next to a fake binary: `exit 2` → exit code 2 with only the binary's stderr; success → exit 0 with stdout/stderr passed through; missing binary → one-line message, exit 1
- [x] `make build`, `make test` unchanged (the wrapper is not part of the Go build)
- [ ] After the next release: `npx zeabur@latest service exec ... -- sh -c 'exit 2'` returns 2 with no Node stack trace

Refs DES-909

Generated with [Claude Code](https://claude.com/claude-code)