### PR TITLE
fix: exit non-zero when a command fails

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,13 +33,14 @@ func main() {
 		os.Args = append([]string{os.Args[0], "deploy"}, os.Args[1:]...)
 	}
 
-	// log errors
+	// log errors and exit non-zero so callers can tell a failure from success
 	if err := rootCmd.Execute(); err != nil {
 		// when some errors occur(such as args dis-match), the log may not be initialized
 		if factory.Log == nil {
 			factory.Log = log.NewInfoLevel()
 		}
 		factory.Log.Error(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `cmd/main.go` logged the error from `rootCmd.Execute()` and then returned normally, so every failure exited 0: unknown command, unknown flag, API 401, missing workspace. Shells (`set -e`, `&&`), CI and the agent sandbox's bash tool all key off the exit status, so failed `zeabur` calls looked like successes. #276 made the npm wrapper mirror the binary's status, which exposed this.
- Fix: `os.Exit(1)` after logging. Output format is unchanged (same `ERROR` line on stderr, `--json` unaffected). Commands that already set their own status (`service exec`, `server exec` forward the remote exit code) are untouched.

## Test plan
- [x] `make test`, `make build` pass
- [x] Built binary, `ZEABUR_TOKEN=zat_bogus`, clean HOME: `bogus-command` → 1, `version --no-such-flag` → 1, `profile info` (401) → 1, `project list --workspace does-not-exist` → 1, `project list` (401) → 1, `version` → 0
- [ ] After release: `npx zeabur@latest bogus-command; echo $?` prints 1

## Noticed, not fixed here
- With no token and `-i=false`, `zeabur profile info` blocks waiting for the browser login callback instead of failing fast. Non-interactive mode should error out; separate issue.

Generated with [Claude Code](https://claude.com/claude-code)